### PR TITLE
Add status bar context menu listener

### DIFF
--- a/packages/status-bar-worker/src/parts/ContextMenu/ContextMenu.ts
+++ b/packages/status-bar-worker/src/parts/ContextMenu/ContextMenu.ts
@@ -1,0 +1,6 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { ContextMenuProps } from '../ContextMenuProps/ContextMenuProps.ts'
+
+export const show2 = async (uid: number, menuId: ContextMenuProps['menuId'], x: number, y: number, args: ContextMenuProps): Promise<void> => {
+  await RendererWorker.showContextMenu2(uid, menuId, x, y, args)
+}

--- a/packages/status-bar-worker/src/parts/ContextMenuProps/ContextMenuProps.ts
+++ b/packages/status-bar-worker/src/parts/ContextMenuProps/ContextMenuProps.ts
@@ -1,0 +1,5 @@
+import type * as MenuEntryId from '../MenuEntryId/MenuEntryId.ts'
+
+export interface ContextMenuProps {
+  readonly menuId: typeof MenuEntryId.StatusBar
+}

--- a/packages/status-bar-worker/src/parts/HandleContextMenu/HandleContextMenu.ts
+++ b/packages/status-bar-worker/src/parts/HandleContextMenu/HandleContextMenu.ts
@@ -1,5 +1,10 @@
 import type { StatusBarState } from '../StatusBarState/StatusBarState.ts'
+import * as ContextMenu from '../ContextMenu/ContextMenu.ts'
+import * as MenuEntryId from '../MenuEntryId/MenuEntryId.ts'
 
-export const handleContextMenu = async (state: StatusBarState): Promise<StatusBarState> => {
+export const handleContextMenu = async (state: StatusBarState, button: number, x: number, y: number): Promise<StatusBarState> => {
+  await ContextMenu.show2(state.uid, MenuEntryId.StatusBar, x, y, {
+    menuId: MenuEntryId.StatusBar,
+  })
   return state
 }

--- a/packages/status-bar-worker/src/parts/MenuEntryId/MenuEntryId.ts
+++ b/packages/status-bar-worker/src/parts/MenuEntryId/MenuEntryId.ts
@@ -1,0 +1,1 @@
+export const StatusBar = 31

--- a/packages/status-bar-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/status-bar-worker/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -6,7 +6,7 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
   return [
     {
       name: DomEventListenersFunctions.HandleContextMenu,
-      params: ['handleContextMenu'],
+      params: ['handleContextMenu', EventExpression.Button, EventExpression.ClientX, EventExpression.ClientY],
       preventDefault: true,
     },
     {

--- a/packages/status-bar-worker/test/HandleContextMenu.test.ts
+++ b/packages/status-bar-worker/test/HandleContextMenu.test.ts
@@ -1,9 +1,29 @@
 import { expect, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as HandleContextMenu from '../src/parts/HandleContextMenu/HandleContextMenu.ts'
+import * as MenuEntryId from '../src/parts/MenuEntryId/MenuEntryId.ts'
 
-test('handleContextMenu should return the same state object', async () => {
-  const state = createDefaultState()
-  const result = await HandleContextMenu.handleContextMenu(state)
+test('handleContextMenu should show status bar context menu', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ContextMenu.show2': async () => {},
+  })
+  const state = {
+    ...createDefaultState(),
+    uid: 1,
+  }
+  const result = await HandleContextMenu.handleContextMenu(state, 2, 100, 200)
   expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([
+    [
+      'ContextMenu.show2',
+      1,
+      MenuEntryId.StatusBar,
+      100,
+      200,
+      {
+        menuId: MenuEntryId.StatusBar,
+      },
+    ],
+  ])
 })

--- a/packages/status-bar-worker/test/RenderEventListeners.test.ts
+++ b/packages/status-bar-worker/test/RenderEventListeners.test.ts
@@ -8,7 +8,7 @@ test('renderEventListeners should return array with click and context menu event
   expect(result).toEqual([
     {
       name: DomEventListenersFunctions.HandleContextMenu,
-      params: ['handleContextMenu'],
+      params: ['handleContextMenu', EventExpression.Button, EventExpression.ClientX, EventExpression.ClientY],
       preventDefault: true,
     },
     {


### PR DESCRIPTION
Adds a context menu listener for the status bar and opens the status bar context menu at the pointer location.