### PR TITLE
fix: handle clicks on status bar item content

### DIFF
--- a/packages/status-bar-worker/src/parts/GetStatusBarItemElementVirtualDom/GetStatusBarItemElementVirtualDom.ts
+++ b/packages/status-bar-worker/src/parts/GetStatusBarItemElementVirtualDom/GetStatusBarItemElementVirtualDom.ts
@@ -2,33 +2,35 @@ import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { ClassNames, mergeClassNames, text, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { StatusBarItemElement } from '../StatusBarItemElement/StatusBarItemElement.ts'
 
-const getTextVirtualDom = (element: StatusBarItemElement): readonly VirtualDomNode[] => {
+const getTextVirtualDom = (element: StatusBarItemElement, name: string): readonly VirtualDomNode[] => {
   return [
     {
       childCount: 1,
       className: 'StatusBarItemLabel',
+      name,
       type: VirtualDomElements.Span,
     },
     text(element.value),
   ]
 }
 
-const getIconVirtualDom = (element: StatusBarItemElement): readonly VirtualDomNode[] => {
+const getIconVirtualDom = (element: StatusBarItemElement, name: string): readonly VirtualDomNode[] => {
   return [
     {
       childCount: 0,
       className: mergeClassNames(ClassNames.MaskIcon, element.value),
+      name,
       type: VirtualDomElements.Div,
     },
   ]
 }
 
-export const getStatusBarItemElementVirtualDom = (element: StatusBarItemElement): readonly VirtualDomNode[] => {
+export const getStatusBarItemElementVirtualDom = (element: StatusBarItemElement, name: string): readonly VirtualDomNode[] => {
   if (element.type === 'text') {
-    return getTextVirtualDom(element)
+    return getTextVirtualDom(element, name)
   }
   if (element.type === 'icon') {
-    return getIconVirtualDom(element)
+    return getIconVirtualDom(element, name)
   }
   return []
 }

--- a/packages/status-bar-worker/src/parts/GetStatusBarItemVirtualDom/GetStatusBarItemVirtualDom.ts
+++ b/packages/status-bar-worker/src/parts/GetStatusBarItemVirtualDom/GetStatusBarItemVirtualDom.ts
@@ -6,7 +6,7 @@ import { getStatusBarItemElementVirtualDom } from '../GetStatusBarItemElementVir
 
 export const getStatusBarItemVirtualDom = (statusBarItem: StatusBarItem): readonly VirtualDomNode[] => {
   const { ariaLabel, elements, name, tooltip } = statusBarItem
-  const elementNodes = elements.flatMap(getStatusBarItemElementVirtualDom)
+  const elementNodes = elements.flatMap((element) => getStatusBarItemElementVirtualDom(element, name))
   const buttonNode: VirtualDomNode = {
     ariaLabel,
     childCount: elements.length,

--- a/packages/status-bar-worker/test/GetStatusBarItemVirtualDom.test.ts
+++ b/packages/status-bar-worker/test/GetStatusBarItemVirtualDom.test.ts
@@ -29,11 +29,13 @@ test('getStatusBarItemVirtualDom should return button with icon and text element
   expect(result[1]).toEqual({
     childCount: 0,
     className: 'MaskIcon test-icon',
+    name: 'test.item',
     type: VirtualDomElements.Div,
   })
   expect(result[2]).toEqual({
     childCount: 1,
     className: 'StatusBarItemLabel',
+    name: 'test.item',
     type: VirtualDomElements.Span,
   })
   expect(result[3]).toEqual({
@@ -65,6 +67,7 @@ test('getStatusBarItemVirtualDom should return button with text element', () => 
   expect(result[1]).toEqual({
     childCount: 1,
     className: 'StatusBarItemLabel',
+    name: 'test.item',
     type: VirtualDomElements.Span,
   })
   expect(result[2]).toEqual({
@@ -96,6 +99,7 @@ test('getStatusBarItemVirtualDom should handle empty strings', () => {
   expect(result[1]).toEqual({
     childCount: 1,
     className: 'StatusBarItemLabel',
+    name: '',
     type: VirtualDomElements.Span,
   })
   expect(result[2]).toEqual({

--- a/packages/status-bar-worker/test/GetStatusBarItemsVirtualDom.test.ts
+++ b/packages/status-bar-worker/test/GetStatusBarItemsVirtualDom.test.ts
@@ -37,6 +37,7 @@ test('getStatusBarItemsVirtualDom should return container div with single item',
   expect(result[2]).toEqual({
     childCount: 1,
     className: 'StatusBarItemLabel',
+    name: 'test.item',
     type: VirtualDomElements.Span,
   })
   expect(result[3]).toEqual({
@@ -81,6 +82,7 @@ test('getStatusBarItemsVirtualDom should return container div with multiple item
   expect(result[2]).toEqual({
     childCount: 1,
     className: 'StatusBarItemLabel',
+    name: 'item1',
     type: VirtualDomElements.Span,
   })
   expect(result[3]).toEqual({
@@ -101,6 +103,7 @@ test('getStatusBarItemsVirtualDom should return container div with multiple item
   expect(result[5]).toEqual({
     childCount: 1,
     className: 'StatusBarItemLabel',
+    name: 'item2',
     type: VirtualDomElements.Span,
   })
   expect(result[6]).toEqual({
@@ -160,11 +163,13 @@ test('getStatusBarItemsVirtualDom should handle items with all fields', () => {
   expect(result[2]).toEqual({
     childCount: 0,
     className: 'MaskIcon test-icon',
+    name: 'test.item',
     type: VirtualDomElements.Div,
   })
   expect(result[3]).toEqual({
     childCount: 1,
     className: 'StatusBarItemLabel',
+    name: 'test.item',
     type: VirtualDomElements.Span,
   })
   expect(result[4]).toEqual({


### PR DESCRIPTION
## Summary

- propagate each status-bar command name onto its rendered icon and label elements
- ensure delegated clicks resolve the command even when the pointer lands on nested content
- update virtual-DOM coverage for text, icon, single-item, and multi-item rendering

## Validation

- `nice -n 10 npm test -- --runInBand` — 33 suites, 199 tests
- `nice -n 10 npm run type-check`
- `nice -n 10 npm run lint`
- `nice -n 10 npm run build`
- integrated LVCE check: an ordinary pointer click on the Git `main` status item opens the branch quick pick with 12 options
