### PR TITLE
fix: add titles to status bar items

### DIFF
--- a/packages/status-bar-worker/src/parts/ToStatusBarItem/ToStatusBarItem.ts
+++ b/packages/status-bar-worker/src/parts/ToStatusBarItem/ToStatusBarItem.ts
@@ -13,11 +13,12 @@ export const toStatusBarItem = (uiStatusBarItem: UiStatusBarItem): StatusBarItem
     elements.push({ type: 'text', value: '' })
   }
   const ariaLabel = uiStatusBarItem.text || uiStatusBarItem.tooltip || uiStatusBarItem.name
+  const tooltip = uiStatusBarItem.tooltip || ariaLabel
   return {
     ariaLabel,
     command: uiStatusBarItem.command || undefined,
     elements,
     name: uiStatusBarItem.name,
-    tooltip: uiStatusBarItem.tooltip,
+    tooltip,
   }
 }

--- a/packages/status-bar-worker/test/StatusBarItemConversion.test.ts
+++ b/packages/status-bar-worker/test/StatusBarItemConversion.test.ts
@@ -47,6 +47,34 @@ test('toStatusBarItem should use fallback text element and aria label', () => {
   })
 })
 
+test('toStatusBarItem should use text as tooltip when tooltip is empty', () => {
+  const uiStatusBarItem: UiStatusBarItem = {
+    command: '',
+    icon: '',
+    name: 'test',
+    text: 'Test',
+    tooltip: '',
+  }
+
+  const result = ToStatusBarItem.toStatusBarItem(uiStatusBarItem)
+
+  expect(result.tooltip).toBe('Test')
+})
+
+test('toStatusBarItem should use name as tooltip when tooltip and text are empty', () => {
+  const uiStatusBarItem: UiStatusBarItem = {
+    command: '',
+    icon: '',
+    name: 'test',
+    text: '',
+    tooltip: '',
+  }
+
+  const result = ToStatusBarItem.toStatusBarItem(uiStatusBarItem)
+
+  expect(result.tooltip).toBe('test')
+})
+
 test('toUiStatusBarItem should normalize branch icon', () => {
   const result = ToUiStatusBarItem.toUiStatusBarItem({
     command: 'test.command',


### PR DESCRIPTION
Ensure status bar items without an explicit tooltip still expose a useful title derived from their visible text or item name.