### PR TITLE
fix: render git branch status bar icon

### DIFF
--- a/packages/status-bar-worker/src/parts/ToUiStatusBarItem/ToUiStatusBarItem.ts
+++ b/packages/status-bar-worker/src/parts/ToUiStatusBarItem/ToUiStatusBarItem.ts
@@ -2,7 +2,7 @@ import type { UiStatusBarItem } from '../UiStatusBarItem/UiStatusBarItem.ts'
 
 const getActualIcon = (extensionHostStatusBarItem: any): string => {
   if (extensionHostStatusBarItem.icon === 'branch') {
-    return 'Branch'
+    return 'MaskIconSourceControl'
   }
   return extensionHostStatusBarItem.icon || ''
 }

--- a/packages/status-bar-worker/test/StatusBarItemConversion.test.ts
+++ b/packages/status-bar-worker/test/StatusBarItemConversion.test.ts
@@ -86,11 +86,26 @@ test('toUiStatusBarItem should normalize branch icon', () => {
 
   expect(result).toEqual({
     command: 'test.command',
-    icon: 'Branch',
+    icon: 'MaskIconSourceControl',
     name: 'test',
     text: 'Test',
     tooltip: 'Test tooltip',
   })
+})
+
+test('toStatusBarItem should render the normalized branch mask icon class', () => {
+  const uiStatusBarItem = ToUiStatusBarItem.toUiStatusBarItem({
+    icon: 'branch',
+    id: 'git.checkout',
+    text: 'main',
+  })
+
+  const result = ToStatusBarItem.toStatusBarItem(uiStatusBarItem)
+
+  expect(result.elements).toEqual([
+    { type: 'icon', value: 'MaskIconSourceControl' },
+    { type: 'text', value: 'main' },
+  ])
 })
 
 test('toUiStatusBarItems should return empty array for missing items', () => {


### PR DESCRIPTION
Normalize the Git branch status bar icon to the existing source-control mask class so it renders correctly.