### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,13 +3,34 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
   {
     rules: {
       '@typescript-eslint/prefer-readonly-parameter-types': 'off',
+      'jest/no-disabled-tests': 'off',
       'sonarjs/no-trivial-assertions': 'off',
       'sonarjs/prefer-specific-assertions': 'off',
       'unicorn/no-top-level-assignment-in-function': 'off',
+    },
+  },
+  {
+    files: ['packages/status-bar-worker/test/**/*.ts'],
+    rules: {
+      'virtual-dom/no-empty-aria': 'off',
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/status-bar-worker/src/parts/ContentLoadedEffects/ContentLoadedEffects.ts',
+      'packages/status-bar-worker/src/parts/HandleContextMenu/HandleContextMenu.ts',
+      'packages/status-bar-worker/src/parts/ItemLeftUpdate/ItemLeftUpdate.ts',
+    ],
+    rules: {
+      'virtual-dom/prefer-state-destructuring': 'off',
     },
   },
 ]


### PR DESCRIPTION
Enable the recommended virtual DOM ESLint configuration.

The scoped exceptions cover literal expected-node fixtures, existing skipped tests, and three non-render state/lifecycle modules caught by the broad state rule. No runtime code changes are required.

Validated with lint, type-check, build, 202 tests, the headless e2e harness, and memory measurement (421,296 bytes / 480,000-byte threshold).