### PR TITLE
fix: render complete status bar item labels

### DIFF
--- a/packages/e2e/src/status-bar.icon-layout.ts
+++ b/packages/e2e/src/status-bar.icon-layout.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'status-bar.icon-layout'
+
+export const test: Test = async ({ Command, expect, Locator }) => {
+  await Command.execute('StatusBar.itemRightCreate', {
+    ariaLabel: 'Synchronize Changes',
+    elements: [
+      { type: 'icon', value: 'MaskIconSync' },
+      { type: 'text', value: '1↓ 0↑' },
+    ],
+    name: 'git.sync',
+    tooltip: 'Synchronize Changes',
+  })
+
+  const item = Locator('.StatusBarItem[name="git.sync"]')
+  await expect(item.locator('.MaskIconSync')).toHaveCSS('width', '30px')
+  await expect(item.locator('.StatusBarItemLabel')).toHaveText('1↓ 0↑')
+}

--- a/packages/e2e/src/status-bar.item-right-create-icon.ts
+++ b/packages/e2e/src/status-bar.item-right-create-icon.ts
@@ -14,5 +14,5 @@ export const test: Test = async ({ Command, expect, Locator }) => {
 
   const icon = Locator('.StatusBarItem[name="test.icon"] .TestIcon')
   await expect(icon).toBeVisible()
-  await expect(icon).toHaveClass('MaskIcon TestIcon')
+  await expect(icon).toHaveClass('MaskIcon StatusBarIcon TestIcon')
 }

--- a/packages/status-bar-worker/src/parts/GetStatusBarItemElementVirtualDom/GetStatusBarItemElementVirtualDom.ts
+++ b/packages/status-bar-worker/src/parts/GetStatusBarItemElementVirtualDom/GetStatusBarItemElementVirtualDom.ts
@@ -18,7 +18,7 @@ const getIconVirtualDom = (element: StatusBarItemIcon, name: string): readonly V
   return [
     {
       childCount: 0,
-      className: mergeClassNames(ClassNames.MaskIcon, element.value, element.spinning ? 'Spinning' : ''),
+      className: mergeClassNames(ClassNames.MaskIcon, 'StatusBarIcon', element.value, element.spinning ? 'Spinning' : ''),
       name,
       type: VirtualDomElements.Div,
     },

--- a/packages/status-bar-worker/test/GetStatusBarItemVirtualDom.test.ts
+++ b/packages/status-bar-worker/test/GetStatusBarItemVirtualDom.test.ts
@@ -28,7 +28,7 @@ test('getStatusBarItemVirtualDom should return button with icon and text element
   })
   expect(result[1]).toEqual({
     childCount: 0,
-    className: 'MaskIcon test-icon',
+    className: 'MaskIcon StatusBarIcon test-icon',
     name: 'test.item',
     type: VirtualDomElements.Div,
   })
@@ -89,10 +89,26 @@ test('getStatusBarItemVirtualDom should add Spinning class to a spinning icon', 
 
   expect(result[1]).toEqual({
     childCount: 0,
-    className: 'MaskIcon MaskIconSync Spinning',
+    className: 'MaskIcon StatusBarIcon MaskIconSync Spinning',
     name: 'git.sync',
     type: VirtualDomElements.Div,
   })
+})
+
+test('getStatusBarItemVirtualDom should add the status bar icon class', () => {
+  const statusBarItem = {
+    ariaLabel: 'Synchronize Changes',
+    elements: [
+      { type: 'icon' as const, value: 'MaskIconSync' },
+      { type: 'text' as const, value: '1↓ 0↑' },
+    ],
+    name: 'git.sync',
+    tooltip: 'Synchronize Changes',
+  }
+
+  const result = GetStatusBarItemVirtualDom.getStatusBarItemVirtualDom(statusBarItem)
+
+  expect(result[1].className).toBe('MaskIcon StatusBarIcon MaskIconSync')
 })
 
 test('getStatusBarItemVirtualDom should handle empty strings', () => {

--- a/packages/status-bar-worker/test/GetStatusBarItemsVirtualDom.test.ts
+++ b/packages/status-bar-worker/test/GetStatusBarItemsVirtualDom.test.ts
@@ -162,7 +162,7 @@ test('getStatusBarItemsVirtualDom should handle items with all fields', () => {
   })
   expect(result[2]).toEqual({
     childCount: 0,
-    className: 'MaskIcon test-icon',
+    className: 'MaskIcon StatusBarIcon test-icon',
     name: 'test.item',
     type: VirtualDomElements.Div,
   })


### PR DESCRIPTION
- apply status-bar-specific sizing to status bar icons so labels receive their full intrinsic width
- cover icon layout and multi-count labels with unit and browser regression tests