### PR TITLE
fix: preserve status bar aria labels

### DIFF
--- a/packages/status-bar-worker/src/parts/ToStatusBarItem/ToStatusBarItem.ts
+++ b/packages/status-bar-worker/src/parts/ToStatusBarItem/ToStatusBarItem.ts
@@ -16,7 +16,7 @@ export const toStatusBarItem = (uiStatusBarItem: UiStatusBarItem): StatusBarItem
   if (elements.length === 0) {
     elements.push({ type: 'text', value: '' })
   }
-  const ariaLabel = uiStatusBarItem.text || uiStatusBarItem.tooltip || uiStatusBarItem.name
+  const ariaLabel = uiStatusBarItem.ariaLabel || uiStatusBarItem.text || uiStatusBarItem.tooltip || uiStatusBarItem.name
   const tooltip = uiStatusBarItem.tooltip || ariaLabel
   return {
     ariaLabel,

--- a/packages/status-bar-worker/src/parts/ToUiStatusBarItem/ToUiStatusBarItem.ts
+++ b/packages/status-bar-worker/src/parts/ToUiStatusBarItem/ToUiStatusBarItem.ts
@@ -9,6 +9,7 @@ const getActualIcon = (extensionHostStatusBarItem: any): string => {
 
 export const toUiStatusBarItem = (extensionHostStatusBarItem: any): UiStatusBarItem => {
   return {
+    ariaLabel: extensionHostStatusBarItem.ariaLabel || '',
     command: extensionHostStatusBarItem.command || '',
     icon: getActualIcon(extensionHostStatusBarItem),
     name: extensionHostStatusBarItem.id || extensionHostStatusBarItem.name || '',

--- a/packages/status-bar-worker/src/parts/UiStatusBarItem/UiStatusBarItem.ts
+++ b/packages/status-bar-worker/src/parts/UiStatusBarItem/UiStatusBarItem.ts
@@ -1,4 +1,5 @@
 export interface UiStatusBarItem {
+  readonly ariaLabel: string
   readonly command: string
   readonly icon: string
   readonly name: string

--- a/packages/status-bar-worker/test/StatusBarItemConversion.test.ts
+++ b/packages/status-bar-worker/test/StatusBarItemConversion.test.ts
@@ -6,6 +6,7 @@ import * as ToUiStatusBarItems from '../src/parts/ToUiStatusBarItems/ToUiStatusB
 
 test('toStatusBarItem should include icon and text elements', () => {
   const uiStatusBarItem: UiStatusBarItem = {
+    ariaLabel: '',
     command: 'test.command',
     icon: 'TestIcon',
     name: 'test',
@@ -29,6 +30,7 @@ test('toStatusBarItem should include icon and text elements', () => {
 
 test('toStatusBarItem should use fallback text element and aria label', () => {
   const uiStatusBarItem: UiStatusBarItem = {
+    ariaLabel: '',
     command: '',
     icon: '',
     name: 'test',
@@ -49,6 +51,7 @@ test('toStatusBarItem should use fallback text element and aria label', () => {
 
 test('toStatusBarItem should use text as tooltip when tooltip is empty', () => {
   const uiStatusBarItem: UiStatusBarItem = {
+    ariaLabel: '',
     command: '',
     icon: '',
     name: 'test',
@@ -63,6 +66,7 @@ test('toStatusBarItem should use text as tooltip when tooltip is empty', () => {
 
 test('toStatusBarItem should use name as tooltip when tooltip and text are empty', () => {
   const uiStatusBarItem: UiStatusBarItem = {
+    ariaLabel: '',
     command: '',
     icon: '',
     name: 'test',
@@ -77,6 +81,7 @@ test('toStatusBarItem should use name as tooltip when tooltip and text are empty
 
 test('toUiStatusBarItem should normalize branch icon', () => {
   const result = ToUiStatusBarItem.toUiStatusBarItem({
+    ariaLabel: 'Current branch is main',
     command: 'test.command',
     icon: 'branch',
     id: 'test',
@@ -85,12 +90,26 @@ test('toUiStatusBarItem should normalize branch icon', () => {
   })
 
   expect(result).toEqual({
+    ariaLabel: 'Current branch is main',
     command: 'test.command',
     icon: 'MaskIconSourceControl',
     name: 'test',
     text: 'Test',
     tooltip: 'Test tooltip',
   })
+})
+
+test('toStatusBarItem should prefer the extension aria label', () => {
+  const uiStatusBarItem = ToUiStatusBarItem.toUiStatusBarItem({
+    ariaLabel: 'workspace (Git) - Pull 2 commits from origin/main',
+    icon: 'MaskIconSync',
+    id: 'git.sync',
+    text: '2↓ 0↑',
+  })
+
+  const result = ToStatusBarItem.toStatusBarItem(uiStatusBarItem)
+
+  expect(result.ariaLabel).toBe('workspace (Git) - Pull 2 commits from origin/main')
 })
 
 test('toStatusBarItem should render the normalized branch mask icon class', () => {


### PR DESCRIPTION
Preserves extension-provided aria labels through status bar conversion so compact visible text can have a descriptive accessible name.