### PR TITLE
Update active problem counts

### DIFF
--- a/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
@@ -6,6 +6,7 @@ import * as HandleContextMenu from '../HandleContextMenu/HandleContextMenu.ts'
 import { handleExtensionManagementMessagePort } from '../HandleExtensionManagementMessagePort/HandleExtensionManagementMessagePort.ts'
 import { handleExtensionsChanged } from '../HandleExtensionsChanged/HandleExtensionsChanged.ts'
 import { handleItemsChanged } from '../HandleItemsChanged/HandleItemsChanged.ts'
+import { handleProblemsSummaryChange } from '../HandleProblemsSummaryChange/HandleProblemsSummaryChange.ts'
 import { initialize } from '../Initialize/Initialize.ts'
 import * as ItemLeftUpdate from '../ItemLeftUpdate/ItemLeftUpdate.ts'
 import * as ItemRightCreate from '../ItemRightCreate/ItemRightCreate.ts'
@@ -27,6 +28,7 @@ export const commandMap = {
   'StatusBar.handleExtensionManagementMessagePort': handleExtensionManagementMessagePort,
   'StatusBar.handleExtensionsChanged': wrapCommand(handleExtensionsChanged),
   'StatusBar.handleItemsChanged': wrapCommand(handleItemsChanged),
+  'StatusBar.handleProblemsSummaryChange': wrapCommand(handleProblemsSummaryChange),
   'StatusBar.initialize': initialize,
   'StatusBar.itemLeftUpdate': wrapCommand(ItemLeftUpdate.itemLeftUpdate),
   'StatusBar.itemRightCreate': wrapCommand(ItemRightCreate.itemRightCreate),

--- a/packages/status-bar-worker/src/parts/HandleProblemsSummaryChange/HandleProblemsSummaryChange.ts
+++ b/packages/status-bar-worker/src/parts/HandleProblemsSummaryChange/HandleProblemsSummaryChange.ts
@@ -1,0 +1,25 @@
+import type { StatusBarState } from '../StatusBarState/StatusBarState.ts'
+import { getProblemsStatusBarItem } from '../GetProblemsStatusBarItem/GetProblemsStatusBarItem.ts'
+import * as InputName from '../InputName/InputName.ts'
+
+interface ProblemsSummary {
+  readonly errorCount: number
+  readonly hasEditor: boolean
+  readonly warningCount: number
+}
+
+export const handleProblemsSummaryChange = (state: StatusBarState, summary: ProblemsSummary): StatusBarState => {
+  const errorCount = summary.hasEditor ? summary.errorCount : 0
+  const warningCount = summary.hasEditor ? summary.warningCount : 0
+  if (state.errorCount === errorCount && state.warningCount === warningCount) {
+    return state
+  }
+  const problemsItem = getProblemsStatusBarItem(errorCount, warningCount, true)[0]
+  const statusBarItemsLeft = state.statusBarItemsLeft.map((item) => (item.name === InputName.Problems ? problemsItem : item))
+  return {
+    ...state,
+    errorCount,
+    statusBarItemsLeft,
+    warningCount,
+  }
+}

--- a/packages/status-bar-worker/src/parts/HandleProblemsSummaryChange/HandleProblemsSummaryChange.ts
+++ b/packages/status-bar-worker/src/parts/HandleProblemsSummaryChange/HandleProblemsSummaryChange.ts
@@ -9,13 +9,14 @@ interface ProblemsSummary {
 }
 
 export const handleProblemsSummaryChange = (state: StatusBarState, summary: ProblemsSummary): StatusBarState => {
+  const { errorCount: oldErrorCount, statusBarItemsLeft: oldStatusBarItemsLeft, warningCount: oldWarningCount } = state
   const errorCount = summary.hasEditor ? summary.errorCount : 0
   const warningCount = summary.hasEditor ? summary.warningCount : 0
-  if (state.errorCount === errorCount && state.warningCount === warningCount) {
+  if (oldErrorCount === errorCount && oldWarningCount === warningCount) {
     return state
   }
   const problemsItem = getProblemsStatusBarItem(errorCount, warningCount, true)[0]
-  const statusBarItemsLeft = state.statusBarItemsLeft.map((item) => (item.name === InputName.Problems ? problemsItem : item))
+  const statusBarItemsLeft = oldStatusBarItemsLeft.map((item) => (item.name === InputName.Problems ? problemsItem : item))
   return {
     ...state,
     errorCount,

--- a/packages/status-bar-worker/test/HandleProblemsSummaryChange.test.ts
+++ b/packages/status-bar-worker/test/HandleProblemsSummaryChange.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { getProblemsStatusBarItem } from '../src/parts/GetProblemsStatusBarItem/GetProblemsStatusBarItem.ts'
+import { handleProblemsSummaryChange } from '../src/parts/HandleProblemsSummaryChange/HandleProblemsSummaryChange.ts'
+
+test('updates the visible Problems item with active editor counts', () => {
+  const state = {
+    ...createDefaultState(),
+    statusBarItemsLeft: getProblemsStatusBarItem(0, 0, true),
+  }
+  const result = handleProblemsSummaryChange(state, {
+    errorCount: 3,
+    hasEditor: true,
+    warningCount: 2,
+  })
+  expect(result.errorCount).toBe(3)
+  expect(result.warningCount).toBe(2)
+  expect(result.statusBarItemsLeft).toEqual(getProblemsStatusBarItem(3, 2, true))
+})
+
+test('clears counts but keeps the Problems item visible when the active editor closes', () => {
+  const state = {
+    ...createDefaultState(),
+    errorCount: 3,
+    statusBarItemsLeft: getProblemsStatusBarItem(3, 2, true),
+    warningCount: 2,
+  }
+  const result = handleProblemsSummaryChange(state, {
+    errorCount: 3,
+    hasEditor: false,
+    warningCount: 2,
+  })
+  expect(result.statusBarItemsLeft).toEqual(getProblemsStatusBarItem(0, 0, true))
+})
+
+test('does not add a Problems item when it is disabled', () => {
+  const state = createDefaultState()
+  const result = handleProblemsSummaryChange(state, {
+    errorCount: 1,
+    hasEditor: true,
+    warningCount: 0,
+  })
+  expect(result.errorCount).toBe(1)
+  expect(result.statusBarItemsLeft).toEqual([])
+})
+
+test('returns the same state when the counts are unchanged', () => {
+  const state = createDefaultState()
+  const result = handleProblemsSummaryChange(state, {
+    errorCount: 0,
+    hasEditor: true,
+    warningCount: 0,
+  })
+  expect(result).toBe(state)
+})


### PR DESCRIPTION
Keep the Problems status-bar item updated with active-editor error and warning counts.