### PR TITLE
Add notification bell and count

### DIFF
--- a/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
@@ -6,6 +6,7 @@ import * as HandleContextMenu from '../HandleContextMenu/HandleContextMenu.ts'
 import { handleExtensionManagementMessagePort } from '../HandleExtensionManagementMessagePort/HandleExtensionManagementMessagePort.ts'
 import { handleExtensionsChanged } from '../HandleExtensionsChanged/HandleExtensionsChanged.ts'
 import { handleItemsChanged } from '../HandleItemsChanged/HandleItemsChanged.ts'
+import { handleNotificationCountChanged } from '../HandleNotificationCountChanged/HandleNotificationCountChanged.ts'
 import { handleProblemsSummaryChange } from '../HandleProblemsSummaryChange/HandleProblemsSummaryChange.ts'
 import { initialize } from '../Initialize/Initialize.ts'
 import * as ItemLeftUpdate from '../ItemLeftUpdate/ItemLeftUpdate.ts'
@@ -28,6 +29,7 @@ export const commandMap = {
   'StatusBar.handleExtensionManagementMessagePort': handleExtensionManagementMessagePort,
   'StatusBar.handleExtensionsChanged': wrapCommand(handleExtensionsChanged),
   'StatusBar.handleItemsChanged': wrapCommand(handleItemsChanged),
+  'StatusBar.handleNotificationCountChanged': wrapCommand(handleNotificationCountChanged),
   'StatusBar.handleProblemsSummaryChange': wrapCommand(handleProblemsSummaryChange),
   'StatusBar.initialize': initialize,
   'StatusBar.itemLeftUpdate': wrapCommand(ItemLeftUpdate.itemLeftUpdate),

--- a/packages/status-bar-worker/src/parts/ExtensionManagementCommandMap/ExtensionManagementCommandMap.ts
+++ b/packages/status-bar-worker/src/parts/ExtensionManagementCommandMap/ExtensionManagementCommandMap.ts
@@ -1,5 +1,7 @@
 import { handleExtensionManagementChange } from '../HandleExtensionManagementChange/HandleExtensionManagementChange.ts'
+import { handleNotificationCountChangedAll } from '../HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts'
 
 export const commandMap = {
   'StatusBar.handleChange': handleExtensionManagementChange,
+  'StatusBar.handleNotificationCountChanged': handleNotificationCountChangedAll,
 }

--- a/packages/status-bar-worker/src/parts/GetBuiltinStatusBarItems/GetBuiltinStatusBarItems.ts
+++ b/packages/status-bar-worker/src/parts/GetBuiltinStatusBarItems/GetBuiltinStatusBarItems.ts
@@ -3,6 +3,7 @@ import { getNotificationsStatusBarItem } from '../GetNotificationsStatusBarItem/
 import { getProblemsStatusBarItem } from '../GetProblemsStatusBarItem/GetProblemsStatusBarItem.ts'
 
 interface GetBuiltinStatusBarItemsOptions {
+  readonly notificationCount?: number
   readonly notificationsEnabled?: boolean
   readonly problemsEnabled?: boolean
 }
@@ -10,7 +11,10 @@ interface GetBuiltinStatusBarItemsOptions {
 export const getBuiltinStatusBarItems = async (
   errorCount: number,
   warningCount: number,
-  { notificationsEnabled = true, problemsEnabled = true }: GetBuiltinStatusBarItemsOptions = {},
+  { notificationCount = 0, notificationsEnabled = true, problemsEnabled = true }: GetBuiltinStatusBarItemsOptions = {},
 ): Promise<readonly StatusBarItem[]> => {
-  return [...getNotificationsStatusBarItem(notificationsEnabled), ...getProblemsStatusBarItem(errorCount, warningCount, problemsEnabled)]
+  return [
+    ...getNotificationsStatusBarItem(notificationsEnabled, notificationCount),
+    ...getProblemsStatusBarItem(errorCount, warningCount, problemsEnabled),
+  ]
 }

--- a/packages/status-bar-worker/src/parts/GetNotificationsStatusBarItem/GetNotificationsStatusBarItem.ts
+++ b/packages/status-bar-worker/src/parts/GetNotificationsStatusBarItem/GetNotificationsStatusBarItem.ts
@@ -1,17 +1,27 @@
 import type { StatusBarItem } from '../StatusBarItem/StatusBarItem.ts'
 import * as InputName from '../InputName/InputName.ts'
 
-export const getNotificationsStatusBarItem = (enabled: boolean): readonly StatusBarItem[] => {
+const getAriaLabel = (count: number): string => {
+  if (count === 0) {
+    return 'No Notifications'
+  }
+  if (count === 1) {
+    return '1 Notification'
+  }
+  return `${count} Notifications`
+}
+
+export const getNotificationsStatusBarItem = (enabled: boolean, count = 0): readonly StatusBarItem[] => {
   if (!enabled) {
     return []
   }
   return [
     {
-      ariaLabel: 'Notifications',
-      command: '', // TODO should show notifications center
-      elements: [{ type: 'text', value: 'Notifications' }],
+      ariaLabel: getAriaLabel(count),
+      command: '',
+      elements: [{ type: 'icon', value: 'NotificationBellIcon' }, ...(count > 0 ? [{ type: 'text' as const, value: String(count) }] : [])],
       name: InputName.Notifications,
-      tooltip: 'Notifications',
+      tooltip: getAriaLabel(count),
     },
   ]
 }

--- a/packages/status-bar-worker/src/parts/GetStatusBarItems/GetStatusBarItems.ts
+++ b/packages/status-bar-worker/src/parts/GetStatusBarItems/GetStatusBarItems.ts
@@ -5,6 +5,14 @@ import { getExtensionStatusBarItems } from '../GetExtensionStatusBarItems/GetExt
 import * as ToStatusBarItem from '../ToStatusBarItem/ToStatusBarItem.ts'
 import * as ToUiStatusBarItems from '../ToUiStatusBarItems/ToUiStatusBarItems.ts'
 
+const getNotificationCount = async (): Promise<number> => {
+  try {
+    return await ExtensionManagementWorker.invoke('Extensions.getNotificationCount')
+  } catch {
+    return 0
+  }
+}
+
 export const getStatusBarItems = async ({
   assetDir,
   builtinNotificationsEnabled = true,
@@ -18,10 +26,13 @@ export const getStatusBarItems = async ({
     return []
   }
   const extensionStatusBarItems = await getExtensionStatusBarItems(assetDir, platform)
+  const notificationCount = await getNotificationCount()
   const uiStatusBarItems = ToUiStatusBarItems.toUiStatusBarItems(extensionStatusBarItems)
   const extraItems = await getBuiltinStatusBarItems(errorCount, warningCount, {
+    notificationCount,
     notificationsEnabled: builtinNotificationsEnabled,
     problemsEnabled: builtinProblemsEnabled,
   })
   return [...uiStatusBarItems.map(ToStatusBarItem.toStatusBarItem), ...extraItems]
 }
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'

--- a/packages/status-bar-worker/src/parts/HandleClickNotification/HandleClickNotification.ts
+++ b/packages/status-bar-worker/src/parts/HandleClickNotification/HandleClickNotification.ts
@@ -1,3 +1,5 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
 export const handleClickNotification = async (): Promise<void> => {
-  // TODO toggle notifications
+  await RendererWorker.invoke('Viewlet.openWidget', 'NotificationCenter')
 }

--- a/packages/status-bar-worker/src/parts/HandleNotificationCountChanged/HandleNotificationCountChanged.ts
+++ b/packages/status-bar-worker/src/parts/HandleNotificationCountChanged/HandleNotificationCountChanged.ts
@@ -1,0 +1,15 @@
+import type { StatusBarState } from '../StatusBarState/StatusBarState.ts'
+import { getNotificationsStatusBarItem } from '../GetNotificationsStatusBarItem/GetNotificationsStatusBarItem.ts'
+import * as InputName from '../InputName/InputName.ts'
+
+export const handleNotificationCountChanged = (state: StatusBarState, count: number): StatusBarState => {
+  const { statusBarItemsRight } = state
+  const notificationsEnabled = statusBarItemsRight.some((item) => item.name === InputName.Notifications)
+  if (!notificationsEnabled) {
+    return state
+  }
+  return {
+    ...state,
+    statusBarItemsRight: getNotificationsStatusBarItem(true, count),
+  }
+}

--- a/packages/status-bar-worker/src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts
+++ b/packages/status-bar-worker/src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts
@@ -1,0 +1,13 @@
+import { handleNotificationCountChanged } from '../HandleNotificationCountChanged/HandleNotificationCountChanged.ts'
+import * as StatusBarStates from '../StatusBarStates/StatusBarStates.ts'
+
+export const handleNotificationCountChangedAll = async (count: number): Promise<void> => {
+  for (const uid of StatusBarStates.getKeys()) {
+    const { newState, oldState } = StatusBarStates.get(uid)
+    const newerState = handleNotificationCountChanged(newState, count)
+    if (newState === newerState || oldState === newerState) {
+      continue
+    }
+    StatusBarStates.set(uid, oldState, newerState)
+  }
+}

--- a/packages/status-bar-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/status-bar-worker/src/parts/LoadContent/LoadContent.ts
@@ -1,5 +1,6 @@
 import type { StatusBarState } from '../StatusBarState/StatusBarState.ts'
 import * as GetStatusBarItems from '../GetStatusBarItems/GetStatusBarItems.ts'
+import * as InputName from '../InputName/InputName.ts'
 import * as StatusBarPreferences from '../StatusBarPreferences/StatusBarPreferences.ts'
 
 export const loadContent = async (state: StatusBarState): Promise<StatusBarState> => {
@@ -18,8 +19,8 @@ export const loadContent = async (state: StatusBarState): Promise<StatusBarState
     ...state,
     errorCount: 0,
     initial: false,
-    statusBarItemsLeft: [...statusBarItems],
-    statusBarItemsRight: [],
+    statusBarItemsLeft: statusBarItems.filter((item) => item.name !== InputName.Notifications),
+    statusBarItemsRight: statusBarItems.filter((item) => item.name === InputName.Notifications),
     warningCount: 0,
   }
 }

--- a/packages/status-bar-worker/test/GetBuiltinStatusBarItems.test.ts
+++ b/packages/status-bar-worker/test/GetBuiltinStatusBarItems.test.ts
@@ -8,11 +8,11 @@ test('getNotificationsStatusBarItem should return the notifications item', () =>
 
   expect(result).toEqual([
     {
-      ariaLabel: 'Notifications',
+      ariaLabel: 'No Notifications',
       command: '',
-      elements: [{ type: 'text', value: 'Notifications' }],
+      elements: [{ type: 'icon', value: 'NotificationBellIcon' }],
       name: 'Notifications',
-      tooltip: 'Notifications',
+      tooltip: 'No Notifications',
     },
   ])
 })
@@ -53,11 +53,11 @@ test('getBuiltinStatusBarItems should return all builtin items by default', asyn
 
   expect(result).toEqual([
     {
-      ariaLabel: 'Notifications',
+      ariaLabel: 'No Notifications',
       command: '',
-      elements: [{ type: 'text', value: 'Notifications' }],
+      elements: [{ type: 'icon', value: 'NotificationBellIcon' }],
       name: 'Notifications',
-      tooltip: 'Notifications',
+      tooltip: 'No Notifications',
     },
     {
       ariaLabel: 'No Problems',
@@ -102,11 +102,11 @@ test('getBuiltinStatusBarItems should omit problems when disabled', async () => 
 
   expect(result).toEqual([
     {
-      ariaLabel: 'Notifications',
+      ariaLabel: 'No Notifications',
       command: '',
-      elements: [{ type: 'text', value: 'Notifications' }],
+      elements: [{ type: 'icon', value: 'NotificationBellIcon' }],
       name: 'Notifications',
-      tooltip: 'Notifications',
+      tooltip: 'No Notifications',
     },
   ])
 })

--- a/packages/status-bar-worker/test/HandleClick.test.ts
+++ b/packages/status-bar-worker/test/HandleClick.test.ts
@@ -26,6 +26,7 @@ test('handleClick should call handleClickNotification when item is Notifications
   using mockRendererRpc = RendererWorker.registerMockRpc({
     'Layout.showPanel': async () => {},
     'Panel.toggleView': async () => {},
+    'Viewlet.openWidget': async () => {},
   })
 
   const state: StatusBarState = {
@@ -43,8 +44,7 @@ test('handleClick should call handleClickNotification when item is Notifications
 
   await HandleClick.handleClick(state, 'Notifications')
 
-  // HandleClickNotification is a TODO, so it doesn't call any RPC methods yet
-  expect(mockRendererRpc.invocations).toEqual([])
+  expect(mockRendererRpc.invocations).toEqual([['Viewlet.openWidget', 'NotificationCenter']])
 })
 
 test('handleClick should call handleClickProblems when item is Problems', async () => {


### PR DESCRIPTION
Shows the notification bell and live count on the right side of the status bar and opens the notification center when clicked.