### PR TITLE
fix: preserve right status bar items on notification update

### DIFF
--- a/packages/status-bar-worker/src/parts/GetStatusBarItems/GetStatusBarItems.ts
+++ b/packages/status-bar-worker/src/parts/GetStatusBarItems/GetStatusBarItems.ts
@@ -1,3 +1,4 @@
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import type { GetStatusBarItemsOptions } from '../GetStatusBarItemsOptions/GetStatusBarItemsOptions.ts'
 import type { StatusBarItem } from '../StatusBarItem/StatusBarItem.ts'
 import { getBuiltinStatusBarItems } from '../GetBuiltinStatusBarItems/GetBuiltinStatusBarItems.ts'
@@ -35,4 +36,3 @@ export const getStatusBarItems = async ({
   })
   return [...uiStatusBarItems.map(ToStatusBarItem.toStatusBarItem), ...extraItems]
 }
-import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'

--- a/packages/status-bar-worker/src/parts/HandleNotificationCountChanged/HandleNotificationCountChanged.ts
+++ b/packages/status-bar-worker/src/parts/HandleNotificationCountChanged/HandleNotificationCountChanged.ts
@@ -8,8 +8,12 @@ export const handleNotificationCountChanged = (state: StatusBarState, count: num
   if (!notificationsEnabled) {
     return state
   }
+  const [notificationItem] = getNotificationsStatusBarItem(true, count)
+  if (!notificationItem) {
+    return state
+  }
   return {
     ...state,
-    statusBarItemsRight: getNotificationsStatusBarItem(true, count),
+    statusBarItemsRight: statusBarItemsRight.map((item) => (item.name === InputName.Notifications ? notificationItem : item)),
   }
 }

--- a/packages/status-bar-worker/test/HandleNotificationCountChanged.test.ts
+++ b/packages/status-bar-worker/test/HandleNotificationCountChanged.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@jest/globals'
+import type { StatusBarItem } from '../src/parts/StatusBarItem/StatusBarItem.ts'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleNotificationCountChanged } from '../src/parts/HandleNotificationCountChanged/HandleNotificationCountChanged.ts'
+
+const notificationItem: StatusBarItem = {
+  ariaLabel: 'No Notifications',
+  command: '',
+  elements: [{ type: 'icon', value: 'NotificationBellIcon' }],
+  name: 'Notifications',
+  tooltip: 'No Notifications',
+}
+
+const problemsItem: StatusBarItem = {
+  ariaLabel: 'No Problems',
+  command: '',
+  elements: [{ type: 'icon', value: 'error' }],
+  name: 'Problems',
+  tooltip: 'No Problems',
+}
+
+test('updates the notification item and preserves other right-side items', () => {
+  const state = { ...createDefaultState(), statusBarItemsRight: [notificationItem, problemsItem] }
+  const result = handleNotificationCountChanged(state, 2)
+  expect(result.statusBarItemsRight).toEqual([
+    {
+      ariaLabel: '2 Notifications',
+      command: '',
+      elements: [
+        { type: 'icon', value: 'NotificationBellIcon' },
+        { type: 'text', value: '2' },
+      ],
+      name: 'Notifications',
+      tooltip: '2 Notifications',
+    },
+    problemsItem,
+  ])
+})
+
+test('returns the same state when notifications are disabled', () => {
+  const state = { ...createDefaultState(), statusBarItemsRight: [problemsItem] }
+  expect(handleNotificationCountChanged(state, 2)).toBe(state)
+})


### PR DESCRIPTION
## Summary

- update the notification bell in place when its count changes
- preserve Problems and extension-provided right-side status bar items
- normalize the extension-management import position

## Validation

- npm test -- --runInBand (188 tests)
- npm run type-check
- npm run lint
- git diff --check