### PR TITLE
feature: render status bar commands directly

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 480_000
+export const threshold = 482_000
 
 export const instantiations = 20_000
 

--- a/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
@@ -6,6 +6,7 @@ import * as HandleContextMenu from '../HandleContextMenu/HandleContextMenu.ts'
 import { handleExtensionManagementMessagePort } from '../HandleExtensionManagementMessagePort/HandleExtensionManagementMessagePort.ts'
 import { handleExtensionsChanged } from '../HandleExtensionsChanged/HandleExtensionsChanged.ts'
 import { handleItemsChanged } from '../HandleItemsChanged/HandleItemsChanged.ts'
+import * as HandleMessagePort from '../HandleMessagePort/HandleMessagePort.ts'
 import { handleNotificationCountChanged } from '../HandleNotificationCountChanged/HandleNotificationCountChanged.ts'
 import { handleProblemsSummaryChange } from '../HandleProblemsSummaryChange/HandleProblemsSummaryChange.ts'
 import { initialize } from '../Initialize/Initialize.ts'
@@ -29,6 +30,7 @@ export const commandMap = {
   'StatusBar.handleExtensionManagementMessagePort': handleExtensionManagementMessagePort,
   'StatusBar.handleExtensionsChanged': wrapCommand(handleExtensionsChanged),
   'StatusBar.handleItemsChanged': wrapCommand(handleItemsChanged),
+  'StatusBar.handleMessagePort': HandleMessagePort.handleMessagePort,
   'StatusBar.handleNotificationCountChanged': wrapCommand(handleNotificationCountChanged),
   'StatusBar.handleProblemsSummaryChange': wrapCommand(handleProblemsSummaryChange),
   'StatusBar.initialize': initialize,

--- a/packages/status-bar-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/status-bar-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,0 +1,10 @@
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
+
+export const handleMessagePort = async (port: MessagePort): Promise<void> => {
+  const rpc = await PlainMessagePortRpc.create({
+    commandMap: {},
+    messagePort: port,
+  })
+  RendererProcess.set(rpc)
+}

--- a/packages/status-bar-worker/src/parts/Render2/Render2.ts
+++ b/packages/status-bar-worker/src/parts/Render2/Render2.ts
@@ -1,9 +1,21 @@
+import { ViewletCommand } from '@lvce-editor/constants'
 import * as ApplyRender from '../ApplyRender/ApplyRender.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 import * as SourceControlStates from '../StatusBarStates/StatusBarStates.ts'
 
-export const render2 = (uid: number, diffResult: readonly number[]): readonly any[] => {
+const renderDirect = async (uid: number, commands: readonly any[]): Promise<readonly any[]> => {
+  const rendererWorkerCommands = commands.filter((command) => command[0] === ViewletCommand.SetFocusContext)
+  const rendererProcessCommands = commands.filter((command) => command[0] !== ViewletCommand.SetFocusContext)
+  const transactionId = await RendererProcess.invoke('Viewlet.queueCommands', uid, rendererProcessCommands)
+  return [...rendererWorkerCommands, ['Viewlet.commitPending', uid, transactionId]]
+}
+
+export const render2 = (uid: number, diffResult: readonly number[]): readonly any[] | Promise<readonly any[]> => {
   const { newState, oldState } = SourceControlStates.get(uid)
   SourceControlStates.set(uid, newState, newState)
   const commands = ApplyRender.applyRender(oldState, newState, diffResult)
-  return commands
+  if (!RendererProcess.isConnected()) {
+    return commands
+  }
+  return renderDirect(uid, commands)
 }

--- a/packages/status-bar-worker/src/parts/RendererProcess/RendererProcess.ts
+++ b/packages/status-bar-worker/src/parts/RendererProcess/RendererProcess.ts
@@ -1,0 +1,20 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
+
+const state = {
+  connected: false,
+}
+
+export const isConnected = (): boolean => {
+  const { connected } = state
+  return connected
+}
+
+export const invoke = (method: string, ...params: readonly unknown[]): Promise<any> => {
+  return RendererProcessRegistry.invoke(method, ...params)
+}
+
+export const set = (rpc: Rpc): void => {
+  RendererProcessRegistry.set(rpc)
+  state.connected = true
+}

--- a/packages/status-bar-worker/test/HandleMessagePort.test.ts
+++ b/packages/status-bar-worker/test/HandleMessagePort.test.ts
@@ -1,0 +1,22 @@
+import { expect, jest, test } from '@jest/globals'
+import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess } from '@lvce-editor/rpc-registry'
+import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+
+test('handleMessagePort connects the status bar worker to the renderer process', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
+  const { port1, port2 } = new MessageChannel()
+  const rendererProcessRpc = await PlainMessagePortRpcParent.create({
+    commandMap: {
+      'Viewlet.queueCommands': queueCommands,
+    },
+    messagePort: port1,
+  })
+
+  await handleMessagePort(port2)
+  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', []]])).resolves.toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', []]])
+
+  await RendererProcess.dispose()
+  await rendererProcessRpc.dispose()
+})

--- a/packages/status-bar-worker/test/Render2.test.ts
+++ b/packages/status-bar-worker/test/Render2.test.ts
@@ -1,0 +1,30 @@
+import { expect, jest, test } from '@jest/globals'
+import { createMockRpc } from '@lvce-editor/rpc'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as DiffType from '../src/parts/DiffType/DiffType.ts'
+import * as Render2 from '../src/parts/Render2/Render2.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
+import * as StatusBarStates from '../src/parts/StatusBarStates/StatusBarStates.ts'
+
+test('render2 returns renderer commands when no direct renderer is connected', () => {
+  const uid = 1
+  const oldState = createDefaultState()
+  const newState = { ...oldState, uid }
+  StatusBarStates.set(uid, oldState, newState)
+
+  expect(Render2.render2(uid, [DiffType.RenderItems])).toEqual([['Viewlet.setDom2', uid, []]])
+})
+
+test('render2 queues renderer commands and returns a lightweight commit marker', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 17)
+  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': queueCommands } }))
+  const uid = 2
+  const oldState = createDefaultState()
+  const newState = { ...oldState, uid }
+  StatusBarStates.set(uid, oldState, newState)
+
+  const result = await Render2.render2(uid, [DiffType.RenderItems])
+
+  expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.setDom2', uid, []]])
+  expect(result).toEqual([['Viewlet.commitPending', uid, 17]])
+})


### PR DESCRIPTION
Connects the status bar worker directly to the renderer process and queues render commands over the dedicated port while preserving the legacy fallback.