### PR TITLE
fix: render direct status bar updates

### DIFF
--- a/packages/status-bar-worker/src/parts/HandleExtensionManagementChange/HandleExtensionManagementChange.ts
+++ b/packages/status-bar-worker/src/parts/HandleExtensionManagementChange/HandleExtensionManagementChange.ts
@@ -1,17 +1,8 @@
-import { handleItemsChanged } from '../HandleItemsChanged/HandleItemsChanged.ts'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as StatusBarStates from '../StatusBarStates/StatusBarStates.ts'
 
 export const handleExtensionManagementChange = async (): Promise<void> => {
-  const uids = StatusBarStates.getKeys()
-  for (const uid of uids) {
-    const { newState, oldState } = StatusBarStates.get(uid)
-    const newerState = await handleItemsChanged(newState)
-    if (newState === newerState || oldState === newerState) {
-      continue
-    }
-    StatusBarStates.set(uid, oldState, {
-      ...newState,
-      ...newerState,
-    })
+  for (const uid of StatusBarStates.getKeys()) {
+    await RendererWorker.invoke('Viewlet.executeViewletCommand', uid, 'handleItemsChanged')
   }
 }

--- a/packages/status-bar-worker/src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts
+++ b/packages/status-bar-worker/src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts
@@ -1,13 +1,8 @@
-import { handleNotificationCountChanged } from '../HandleNotificationCountChanged/HandleNotificationCountChanged.ts'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as StatusBarStates from '../StatusBarStates/StatusBarStates.ts'
 
 export const handleNotificationCountChangedAll = async (count: number): Promise<void> => {
   for (const uid of StatusBarStates.getKeys()) {
-    const { newState, oldState } = StatusBarStates.get(uid)
-    const newerState = handleNotificationCountChanged(newState, count)
-    if (newState === newerState || oldState === newerState) {
-      continue
-    }
-    StatusBarStates.set(uid, oldState, newerState)
+    await RendererWorker.invoke('Viewlet.executeViewletCommand', uid, 'handleNotificationCountChanged', count)
   }
 }

--- a/packages/status-bar-worker/test/HandleExtensionManagementChange.test.ts
+++ b/packages/status-bar-worker/test/HandleExtensionManagementChange.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleExtensionManagementChange } from '../src/parts/HandleExtensionManagementChange/HandleExtensionManagementChange.ts'
+import * as StatusBarStates from '../src/parts/StatusBarStates/StatusBarStates.ts'
+
+test('renders extension item changes through the viewlet command pipeline', async () => {
+  const state = createDefaultState()
+  StatusBarStates.set(42, state, state)
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    'Viewlet.executeViewletCommand': async () => {},
+  })
+
+  await handleExtensionManagementChange()
+
+  expect(mockRendererRpc.invocations).toEqual([['Viewlet.executeViewletCommand', 42, 'handleItemsChanged']])
+})

--- a/packages/status-bar-worker/test/HandleNotificationCountChangedAll.test.ts
+++ b/packages/status-bar-worker/test/HandleNotificationCountChangedAll.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleNotificationCountChangedAll } from '../src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts'
+import * as StatusBarStates from '../src/parts/StatusBarStates/StatusBarStates.ts'
+
+test('renders notification count changes through the viewlet command pipeline', async () => {
+  const state = createDefaultState()
+  StatusBarStates.set(42, state, state)
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    'Viewlet.executeViewletCommand': async () => {},
+  })
+
+  await handleNotificationCountChangedAll(3)
+
+  expect(mockRendererRpc.invocations).toEqual([['Viewlet.executeViewletCommand', 42, 'handleNotificationCountChanged', 3]])
+})


### PR DESCRIPTION
## Summary

- feed direct extension-management updates through the renderer viewlet command pipeline
- render notification count changes immediately
- render extension-contributed status item changes without invalid renderer commands
- add focused tests for both direct update paths

## Validation

- npm test
- npm run type-check
- npm run lint
- npm run build