### PR TITLE
fix: render out-of-band status updates

### DIFF
--- a/packages/status-bar-worker/src/parts/HandleExtensionManagementChange/HandleExtensionManagementChange.ts
+++ b/packages/status-bar-worker/src/parts/HandleExtensionManagementChange/HandleExtensionManagementChange.ts
@@ -1,8 +1,15 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { handleItemsChanged } from '../HandleItemsChanged/HandleItemsChanged.ts'
+import { renderOutOfBand } from '../RenderOutOfBand/RenderOutOfBand.ts'
 import * as StatusBarStates from '../StatusBarStates/StatusBarStates.ts'
 
 export const handleExtensionManagementChange = async (): Promise<void> => {
   for (const uid of StatusBarStates.getKeys()) {
-    await RendererWorker.invoke('Viewlet.executeViewletCommand', uid, 'handleItemsChanged')
+    const { newState, oldState } = StatusBarStates.get(uid)
+    const newerState = await handleItemsChanged(newState)
+    if (newState === newerState || oldState === newerState) {
+      continue
+    }
+    StatusBarStates.set(uid, oldState, { ...newState, ...newerState })
+    await renderOutOfBand(uid)
   }
 }

--- a/packages/status-bar-worker/src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts
+++ b/packages/status-bar-worker/src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts
@@ -1,8 +1,15 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { handleNotificationCountChanged } from '../HandleNotificationCountChanged/HandleNotificationCountChanged.ts'
+import { renderOutOfBand } from '../RenderOutOfBand/RenderOutOfBand.ts'
 import * as StatusBarStates from '../StatusBarStates/StatusBarStates.ts'
 
 export const handleNotificationCountChangedAll = async (count: number): Promise<void> => {
   for (const uid of StatusBarStates.getKeys()) {
-    await RendererWorker.invoke('Viewlet.executeViewletCommand', uid, 'handleNotificationCountChanged', count)
+    const { newState, oldState } = StatusBarStates.get(uid)
+    const newerState = handleNotificationCountChanged(newState, count)
+    if (newState === newerState || oldState === newerState) {
+      continue
+    }
+    StatusBarStates.set(uid, oldState, newerState)
+    await renderOutOfBand(uid)
   }
 }

--- a/packages/status-bar-worker/src/parts/RenderOutOfBand/RenderOutOfBand.ts
+++ b/packages/status-bar-worker/src/parts/RenderOutOfBand/RenderOutOfBand.ts
@@ -1,0 +1,18 @@
+import { diff2 } from '../Diff2/Diff2.ts'
+import { render2 } from '../Render2/Render2.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
+
+export const renderOutOfBand = async (uid: number): Promise<void> => {
+  if (!RendererProcess.isConnected()) {
+    return
+  }
+  const diffResult = diff2(uid)
+  if (diffResult.length === 0) {
+    return
+  }
+  const commands = await render2(uid, diffResult)
+  if (commands.length === 0) {
+    return
+  }
+  await RendererProcess.invoke('Viewlet.sendMultiple', commands)
+}

--- a/packages/status-bar-worker/test/HandleExtensionManagementChange.test.ts
+++ b/packages/status-bar-worker/test/HandleExtensionManagementChange.test.ts
@@ -1,17 +1,30 @@
-import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { expect, jest, test } from '@jest/globals'
+import { createMockRpc } from '@lvce-editor/rpc'
+import { ExtensionManagementWorker } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleExtensionManagementChange } from '../src/parts/HandleExtensionManagementChange/HandleExtensionManagementChange.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 import * as StatusBarStates from '../src/parts/StatusBarStates/StatusBarStates.ts'
 
-test('renders extension item changes through the viewlet command pipeline', async () => {
-  const state = createDefaultState()
-  StatusBarStates.set(42, state, state)
-  using mockRendererRpc = RendererWorker.registerMockRpc({
-    'Viewlet.executeViewletCommand': async () => {},
+test('renders extension item changes through the direct renderer connection', async () => {
+  using mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.activateByEvent': async () => {},
+    'Extensions.getNotificationCount': async () => 0,
+    'Extensions.getStatusBarItems': async () => [{ id: 'sample.status', text: 'Ready' }],
   })
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 17)
+  const sendMultiple = jest.fn()
+  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': queueCommands, 'Viewlet.sendMultiple': sendMultiple } }))
+  const state = { ...createDefaultState(), initial: false, uid: 42 }
+  StatusBarStates.set(42, state, state)
 
   await handleExtensionManagementChange()
 
-  expect(mockRendererRpc.invocations).toEqual([['Viewlet.executeViewletCommand', 42, 'handleItemsChanged']])
+  expect(mockExtensionManagementRpc.invocations).toEqual([
+    ['Extensions.activateByEvent', 'onStatusBarItem', '', 0],
+    ['Extensions.getStatusBarItems'],
+    ['Extensions.getNotificationCount'],
+  ])
+  expect(queueCommands).toHaveBeenCalledTimes(1)
+  expect(sendMultiple).toHaveBeenCalledWith([['Viewlet.commitPending', 42, 17]])
 })

--- a/packages/status-bar-worker/test/HandleNotificationCountChangedAll.test.ts
+++ b/packages/status-bar-worker/test/HandleNotificationCountChangedAll.test.ts
@@ -1,17 +1,32 @@
-import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { expect, jest, test } from '@jest/globals'
+import { createMockRpc } from '@lvce-editor/rpc'
+import type { StatusBarItem } from '../src/parts/StatusBarItem/StatusBarItem.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleNotificationCountChangedAll } from '../src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 import * as StatusBarStates from '../src/parts/StatusBarStates/StatusBarStates.ts'
 
-test('renders notification count changes through the viewlet command pipeline', async () => {
-  const state = createDefaultState()
+const notificationItem: StatusBarItem = {
+  ariaLabel: 'No Notifications',
+  command: '',
+  elements: [{ type: 'icon', value: 'NotificationBellIcon' }],
+  name: 'Notifications',
+  tooltip: 'No Notifications',
+}
+
+test('renders notification count changes through the direct renderer connection', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 17)
+  const sendMultiple = jest.fn()
+  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': queueCommands, 'Viewlet.sendMultiple': sendMultiple } }))
+  const state = { ...createDefaultState(), initial: false, statusBarItemsRight: [notificationItem], uid: 42 }
   StatusBarStates.set(42, state, state)
-  using mockRendererRpc = RendererWorker.registerMockRpc({
-    'Viewlet.executeViewletCommand': async () => {},
-  })
 
   await handleNotificationCountChangedAll(3)
 
-  expect(mockRendererRpc.invocations).toEqual([['Viewlet.executeViewletCommand', 42, 'handleNotificationCountChanged', 3]])
+  expect(queueCommands).toHaveBeenCalledTimes(1)
+  const [uid, commands] = queueCommands.mock.calls[0]
+  expect(uid).toBe(42)
+  expect((commands[0] as readonly unknown[])[0]).toBe('Viewlet.setDom2')
+  expect(JSON.stringify(commands)).toContain('"ariaLabel":"3 Notifications"')
+  expect(sendMultiple).toHaveBeenCalledWith([['Viewlet.commitPending', 42, 17]])
 })


### PR DESCRIPTION
## Summary

- render direct extension-management updates through the status worker's renderer-process connection
- avoid renderer viewlet lookup before registration
- preserve the normal diff/render pipeline for notification counts and extension status items
- cover both out-of-band render paths

## Validation

- npm test (193 passing)
- npm run type-check
- npm run lint
- npm run build