### PR TITLE
fix: defer status updates until mounted

### DIFF
--- a/packages/status-bar-worker/src/parts/RenderOutOfBand/RenderOutOfBand.ts
+++ b/packages/status-bar-worker/src/parts/RenderOutOfBand/RenderOutOfBand.ts
@@ -1,9 +1,14 @@
 import { diff2 } from '../Diff2/Diff2.ts'
 import { render2 } from '../Render2/Render2.ts'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
+import * as StatusBarStates from '../StatusBarStates/StatusBarStates.ts'
 
 export const renderOutOfBand = async (uid: number): Promise<void> => {
   if (!RendererProcess.isConnected()) {
+    return
+  }
+  const { newState } = StatusBarStates.get(uid)
+  if (newState.initial) {
     return
   }
   const diffResult = diff2(uid)

--- a/packages/status-bar-worker/test/HandleExtensionManagementChange.test.ts
+++ b/packages/status-bar-worker/test/HandleExtensionManagementChange.test.ts
@@ -28,3 +28,28 @@ test('renders extension item changes through the direct renderer connection', as
   expect(queueCommands).toHaveBeenCalledTimes(1)
   expect(sendMultiple).toHaveBeenCalledWith([['Viewlet.commitPending', 42, 17]])
 })
+
+test('defers extension item rendering until the status bar has mounted', async () => {
+  using mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.activateByEvent': async () => {},
+    'Extensions.getNotificationCount': async () => 0,
+    'Extensions.getStatusBarItems': async () => [{ id: 'sample.status', text: 'Ready' }],
+  })
+  const queueCommands = jest.fn()
+  const sendMultiple = jest.fn()
+  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': queueCommands, 'Viewlet.sendMultiple': sendMultiple } }))
+  const state = { ...createDefaultState(), initial: true, uid: 42 }
+  StatusBarStates.set(42, state, state)
+
+  await handleExtensionManagementChange()
+
+  expect(mockExtensionManagementRpc.invocations).toEqual([
+    ['Extensions.activateByEvent', 'onStatusBarItem', '', 0],
+    ['Extensions.getStatusBarItems'],
+    ['Extensions.getNotificationCount'],
+  ])
+  expect(StatusBarStates.get(42).newState.statusBarItemsLeft).toHaveLength(1)
+  expect(StatusBarStates.get(42).newState.statusBarItemsLeft[0].name).toBe('sample.status')
+  expect(queueCommands).not.toHaveBeenCalled()
+  expect(sendMultiple).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## What

Defer out-of-band status bar rendering until the initial status bar content has mounted.

## Why

Extension status updates can arrive after state creation but before the renderer has a DOM root. Sending `SetDom2` during that window causes renderer focus preservation to access a missing root. State changes are retained and included by the normal initial load.

## Validation

- 194 unit tests
- `npm run type-check`
- `npm run lint`
- `npm run build`