### PR TITLE
fix: defer initial empty status render

### DIFF
--- a/packages/status-bar-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/status-bar-worker/src/parts/RenderItems/RenderItems.ts
@@ -5,7 +5,7 @@ import { getStatusBarVirtualDom } from '../GetStatusBarVirtualDom/GetStatusBarVi
 export const renderItems = (oldState: StatusBarState, newState: StatusBarState): any => {
   const { initial, statusBarItemsLeft, statusBarItemsRight, uid } = newState
   if (initial) {
-    return [ViewletCommand.SetDom2, uid, []]
+    return []
   }
   const dom = getStatusBarVirtualDom(statusBarItemsLeft, statusBarItemsRight)
   return [ViewletCommand.SetDom2, uid, dom]

--- a/packages/status-bar-worker/test/ApplyRender.test.ts
+++ b/packages/status-bar-worker/test/ApplyRender.test.ts
@@ -18,6 +18,7 @@ test('applyRender should return commands when diffResult contains RenderItems', 
   const oldState: StatusBarState = createDefaultState()
   const newState: StatusBarState = {
     ...createDefaultState(),
+    initial: false,
     statusBarItemsLeft: [
       {
         ariaLabel: 'Item 1',
@@ -45,6 +46,7 @@ test('applyRender should return multiple commands when diffResult contains multi
   const oldState: StatusBarState = createDefaultState()
   const newState: StatusBarState = {
     ...createDefaultState(),
+    initial: false,
     statusBarItemsLeft: [
       {
         ariaLabel: 'Item 1',

--- a/packages/status-bar-worker/test/Render2.test.ts
+++ b/packages/status-bar-worker/test/Render2.test.ts
@@ -9,10 +9,12 @@ import * as StatusBarStates from '../src/parts/StatusBarStates/StatusBarStates.t
 test('render2 returns renderer commands when no direct renderer is connected', () => {
   const uid = 1
   const oldState = createDefaultState()
-  const newState = { ...oldState, uid }
+  const newState = { ...oldState, initial: false, uid }
   StatusBarStates.set(uid, oldState, newState)
 
-  expect(Render2.render2(uid, [DiffType.RenderItems])).toEqual([['Viewlet.setDom2', uid, []]])
+  const result = Render2.render2(uid, [DiffType.RenderItems]) as readonly unknown[][]
+  expect(result[0][0]).toBe('Viewlet.setDom2')
+  expect(result[0][1]).toBe(uid)
 })
 
 test('render2 queues renderer commands and returns a lightweight commit marker', async () => {
@@ -20,11 +22,11 @@ test('render2 queues renderer commands and returns a lightweight commit marker',
   RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': queueCommands } }))
   const uid = 2
   const oldState = createDefaultState()
-  const newState = { ...oldState, uid }
+  const newState = { ...oldState, initial: false, uid }
   StatusBarStates.set(uid, oldState, newState)
 
   const result = await Render2.render2(uid, [DiffType.RenderItems])
 
-  expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.setDom2', uid, []]])
+  expect(queueCommands).toHaveBeenCalledWith(uid, [expect.arrayContaining(['Viewlet.setDom2', uid])])
   expect(result).toEqual([['Viewlet.commitPending', uid, 17]])
 })

--- a/packages/status-bar-worker/test/RenderItems.test.ts
+++ b/packages/status-bar-worker/test/RenderItems.test.ts
@@ -114,11 +114,20 @@ test('renderItems should return SetDom2 command with items in both sides', () =>
 
 test('renderItems should use uid from newState', () => {
   const oldState: StatusBarState = { ...createDefaultState(), uid: 10 }
-  const newState: StatusBarState = { ...createDefaultState(), uid: 20 }
+  const newState: StatusBarState = { ...createDefaultState(), initial: false, uid: 20 }
 
   const result = RenderItems.renderItems(oldState, newState)
 
   expect(result[1]).toBe(20)
+})
+
+test('renderItems should defer rendering while content is initial', () => {
+  const oldState: StatusBarState = createDefaultState()
+  const newState: StatusBarState = { ...createDefaultState(), initial: true, uid: 20 }
+
+  const result = RenderItems.renderItems(oldState, newState)
+
+  expect(result).toEqual([])
 })
 
 test('renderItems should ignore oldState and only use newState', () => {


### PR DESCRIPTION
## What

Skip the status bar render pass while content is still initial instead of emitting `SetDom2` with an empty virtual DOM.

## Why

The renderer requires a root element. `loadContent` supplies the first complete status-bar DOM on the following frame.

## Validation

- 195 unit tests
- `npm run type-check`
- `npm run lint`
- `npm run build`