### PR TITLE
fix: render initial status bar root

### DIFF
--- a/packages/status-bar-worker/src/parts/RenderItems/RenderItems.ts
+++ b/packages/status-bar-worker/src/parts/RenderItems/RenderItems.ts
@@ -3,10 +3,7 @@ import type { StatusBarState } from '../StatusBarState/StatusBarState.ts'
 import { getStatusBarVirtualDom } from '../GetStatusBarVirtualDom/GetStatusBarVirtualDom.ts'
 
 export const renderItems = (oldState: StatusBarState, newState: StatusBarState): any => {
-  const { initial, statusBarItemsLeft, statusBarItemsRight, uid } = newState
-  if (initial) {
-    return []
-  }
+  const { statusBarItemsLeft, statusBarItemsRight, uid } = newState
   const dom = getStatusBarVirtualDom(statusBarItemsLeft, statusBarItemsRight)
   return [ViewletCommand.SetDom2, uid, dom]
 }

--- a/packages/status-bar-worker/test/RenderItems.test.ts
+++ b/packages/status-bar-worker/test/RenderItems.test.ts
@@ -121,13 +121,15 @@ test('renderItems should use uid from newState', () => {
   expect(result[1]).toBe(20)
 })
 
-test('renderItems should defer rendering while content is initial', () => {
+test('renderItems should render an empty status bar root while content is initial', () => {
   const oldState: StatusBarState = createDefaultState()
   const newState: StatusBarState = { ...createDefaultState(), initial: true, uid: 20 }
 
   const result = RenderItems.renderItems(oldState, newState)
 
-  expect(result).toEqual([])
+  expect(result[0]).toBe(ViewletCommand.SetDom2)
+  expect(result[1]).toBe(20)
+  expect(result[2].length).toBeGreaterThan(0)
 })
 
 test('renderItems should ignore oldState and only use newState', () => {


### PR DESCRIPTION
## What

Render an empty status-bar container during the initial frame instead of emitting an empty virtual DOM or suppressing the root.

## Why

The renderer requires a root element, and the status bar must exist before async content and the notification bell arrive.

## Validation

- 195 unit tests
- `npm run type-check`
- `npm run lint`
- `npm run build`