### PR TITLE
fix: retain initial notification count

### DIFF
--- a/packages/status-bar-worker/src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts
+++ b/packages/status-bar-worker/src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts
@@ -1,8 +1,10 @@
 import { handleNotificationCountChanged } from '../HandleNotificationCountChanged/HandleNotificationCountChanged.ts'
+import * as NotificationCount from '../NotificationCount/NotificationCount.ts'
 import { renderOutOfBand } from '../RenderOutOfBand/RenderOutOfBand.ts'
 import * as StatusBarStates from '../StatusBarStates/StatusBarStates.ts'
 
 export const handleNotificationCountChangedAll = async (count: number): Promise<void> => {
+  NotificationCount.set(count)
   for (const uid of StatusBarStates.getKeys()) {
     const { newState, oldState } = StatusBarStates.get(uid)
     const newerState = handleNotificationCountChanged(newState, count)

--- a/packages/status-bar-worker/src/parts/LoadContent/LoadContent.ts
+++ b/packages/status-bar-worker/src/parts/LoadContent/LoadContent.ts
@@ -1,6 +1,8 @@
 import type { StatusBarState } from '../StatusBarState/StatusBarState.ts'
 import * as GetStatusBarItems from '../GetStatusBarItems/GetStatusBarItems.ts'
+import { handleNotificationCountChanged } from '../HandleNotificationCountChanged/HandleNotificationCountChanged.ts'
 import * as InputName from '../InputName/InputName.ts'
+import * as NotificationCount from '../NotificationCount/NotificationCount.ts'
 import * as StatusBarPreferences from '../StatusBarPreferences/StatusBarPreferences.ts'
 
 export const loadContent = async (state: StatusBarState): Promise<StatusBarState> => {
@@ -15,7 +17,7 @@ export const loadContent = async (state: StatusBarState): Promise<StatusBarState
     showItems: itemsVisible,
     warningCount,
   })
-  return {
+  const loadedState: StatusBarState = {
     ...state,
     errorCount: 0,
     initial: false,
@@ -23,4 +25,9 @@ export const loadContent = async (state: StatusBarState): Promise<StatusBarState
     statusBarItemsRight: statusBarItems.filter((item) => item.name === InputName.Notifications),
     warningCount: 0,
   }
+  const latestNotificationCount = NotificationCount.get()
+  if (latestNotificationCount === undefined) {
+    return loadedState
+  }
+  return handleNotificationCountChanged(loadedState, latestNotificationCount)
 }

--- a/packages/status-bar-worker/src/parts/NotificationCount/NotificationCount.ts
+++ b/packages/status-bar-worker/src/parts/NotificationCount/NotificationCount.ts
@@ -1,0 +1,13 @@
+let latestCount: number | undefined
+
+export const get = (): number | undefined => {
+  return latestCount
+}
+
+export const reset = (): void => {
+  latestCount = undefined
+}
+
+export const set = (count: number): void => {
+  latestCount = count
+}

--- a/packages/status-bar-worker/test/HandleNotificationCountChangedAll.test.ts
+++ b/packages/status-bar-worker/test/HandleNotificationCountChangedAll.test.ts
@@ -1,8 +1,9 @@
-import { expect, jest, test } from '@jest/globals'
+import { afterEach, expect, jest, test } from '@jest/globals'
 import { createMockRpc } from '@lvce-editor/rpc'
 import type { StatusBarItem } from '../src/parts/StatusBarItem/StatusBarItem.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleNotificationCountChangedAll } from '../src/parts/HandleNotificationCountChangedAll/HandleNotificationCountChangedAll.ts'
+import * as NotificationCount from '../src/parts/NotificationCount/NotificationCount.ts'
 import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 import * as StatusBarStates from '../src/parts/StatusBarStates/StatusBarStates.ts'
 
@@ -13,6 +14,16 @@ const notificationItem: StatusBarItem = {
   name: 'Notifications',
   tooltip: 'No Notifications',
 }
+
+afterEach(() => {
+  NotificationCount.reset()
+})
+
+test('retains notification count changes before a status bar instance exists', async () => {
+  await handleNotificationCountChangedAll(3)
+
+  expect(NotificationCount.get()).toBe(3)
+})
 
 test('renders notification count changes through the direct renderer connection', async () => {
   const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 17)

--- a/packages/status-bar-worker/test/LoadContent.test.ts
+++ b/packages/status-bar-worker/test/LoadContent.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, test } from '@jest/globals'
+import { ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { loadContent } from '../src/parts/LoadContent/LoadContent.ts'
+import * as NotificationCount from '../src/parts/NotificationCount/NotificationCount.ts'
+
+afterEach(() => {
+  NotificationCount.reset()
+})
+
+test('uses a notification count received while content is loading', async () => {
+  using rendererWorkerRpc = RendererWorker.registerMockRpc({
+    'Preferences.get': async () => undefined,
+  })
+  using extensionManagementWorkerRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.activateByEvent': async () => {},
+    'Extensions.getNotificationCount': async () => 0,
+    'Extensions.getStatusBarItems': async () => [],
+  })
+  NotificationCount.set(3)
+
+  const result = await loadContent(createDefaultState())
+
+  expect(result.statusBarItemsRight).toHaveLength(1)
+  expect(result.statusBarItemsRight[0].ariaLabel).toBe('3 Notifications')
+  expect(rendererWorkerRpc.invocations).toHaveLength(3)
+  expect(extensionManagementWorkerRpc.invocations).toEqual([
+    ['Extensions.activateByEvent', 'onStatusBarItem', '', 0],
+    ['Extensions.getStatusBarItems'],
+    ['Extensions.getNotificationCount'],
+  ])
+})


### PR DESCRIPTION
Retain notification count updates that arrive while the status bar is still loading, so the bell reflects extension notifications immediately.