### PR TITLE
feature: handle view events directly

### DIFF
--- a/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
@@ -44,3 +44,5 @@ export const commandMap = {
   'StatusBar.saveState': wrapGetter(saveState),
   'StatusBar.terminate': terminate,
 }
+
+HandleMessagePort.setCommandMap(commandMap)

--- a/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/status-bar-worker/src/parts/CommandMap/CommandMap.ts
@@ -20,6 +20,8 @@ import { resize } from '../Resize/Resize.ts'
 import { saveState } from '../SaveState/SaveState.ts'
 import { getCommandIds, wrapCommand, wrapGetter } from '../StatusBarStates/StatusBarStates.ts'
 
+const handleDirectMessagePort = (port: MessagePort): Promise<void> => HandleMessagePort.handleMessagePort(port, commandMap)
+
 export const commandMap = {
   'StatusBar.create': StatusBar.create,
   'StatusBar.diff2': diff2,
@@ -30,7 +32,7 @@ export const commandMap = {
   'StatusBar.handleExtensionManagementMessagePort': handleExtensionManagementMessagePort,
   'StatusBar.handleExtensionsChanged': wrapCommand(handleExtensionsChanged),
   'StatusBar.handleItemsChanged': wrapCommand(handleItemsChanged),
-  'StatusBar.handleMessagePort': HandleMessagePort.handleMessagePort,
+  'StatusBar.handleMessagePort': handleDirectMessagePort,
   'StatusBar.handleNotificationCountChanged': wrapCommand(handleNotificationCountChanged),
   'StatusBar.handleProblemsSummaryChange': wrapCommand(handleProblemsSummaryChange),
   'StatusBar.initialize': initialize,
@@ -44,5 +46,3 @@ export const commandMap = {
   'StatusBar.saveState': wrapGetter(saveState),
   'StatusBar.terminate': terminate,
 }
-
-HandleMessagePort.setCommandMap(commandMap)

--- a/packages/status-bar-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/status-bar-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,9 +1,25 @@
 import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
+
+let viewletCommandMap: Record<string, unknown> = Object.create(null)
+
+export const setCommandMap = (commandMap: object): void => {
+  viewletCommandMap = commandMap as Record<string, unknown>
+}
+
+const executeViewletCommand = async (uid: number, command: string, ...args: readonly any[]): Promise<void> => {
+  const fn = viewletCommandMap[`StatusBar.${command}`]
+  if (typeof fn !== 'function') {
+    throw new Error(`Viewlet command not found: ${command}`)
+  }
+  await fn(uid, ...args)
+  await RendererWorker.invoke('Viewlet.requestRender', uid)
+}
 
 export const handleMessagePort = async (port: MessagePort): Promise<void> => {
   const rpc = await PlainMessagePortRpc.create({
-    commandMap: {},
+    commandMap: { 'Viewlet.executeViewletCommand': executeViewletCommand },
     messagePort: port,
   })
   RendererProcess.set(rpc)

--- a/packages/status-bar-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/status-bar-worker/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -2,24 +2,20 @@ import { PlainMessagePortRpc } from '@lvce-editor/rpc'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
-let viewletCommandMap: Record<string, unknown> = Object.create(null)
-
-export const setCommandMap = (commandMap: object): void => {
-  viewletCommandMap = commandMap as Record<string, unknown>
-}
-
-const executeViewletCommand = async (uid: number, command: string, ...args: readonly any[]): Promise<void> => {
-  const fn = viewletCommandMap[`StatusBar.${command}`]
-  if (typeof fn !== 'function') {
-    throw new Error(`Viewlet command not found: ${command}`)
+export const handleMessagePort = async (port: MessagePort, viewletCommandMap: Readonly<Record<string, unknown>>): Promise<void> => {
+  const executeViewletCommand = async (uid: number, command: string, ...args: readonly any[]): Promise<void> => {
+    const fn = viewletCommandMap[`StatusBar.${command}`]
+    if (typeof fn !== 'function') {
+      throw new TypeError(`Viewlet command not found: ${command}`)
+    }
+    await fn(uid, ...args)
+    await RendererWorker.invoke('Viewlet.requestRender', uid)
   }
-  await fn(uid, ...args)
-  await RendererWorker.invoke('Viewlet.requestRender', uid)
-}
 
-export const handleMessagePort = async (port: MessagePort): Promise<void> => {
   const rpc = await PlainMessagePortRpc.create({
-    commandMap: { 'Viewlet.executeViewletCommand': executeViewletCommand },
+    commandMap: {
+      'Viewlet.executeViewletCommand': executeViewletCommand,
+    },
     messagePort: port,
   })
   RendererProcess.set(rpc)

--- a/packages/status-bar-worker/test/HandleMessagePort.test.ts
+++ b/packages/status-bar-worker/test/HandleMessagePort.test.ts
@@ -1,32 +1,42 @@
 import { expect, jest, test } from '@jest/globals'
 import { createMockRpc, PlainMessagePortRpcParent } from '@lvce-editor/rpc'
-import { RendererProcess, RendererWorker } from '@lvce-editor/rpc-registry'
-import { handleMessagePort, setCommandMap } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+import { RendererProcess as RendererProcessRegistry, RendererWorker } from '@lvce-editor/rpc-registry'
+import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
-test('handleMessagePort connects the status bar worker to the renderer process', async () => {
+test('connects the view directly to the renderer process', async () => {
   const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
   const { port1, port2 } = new MessageChannel()
   const rendererProcessRpc = await PlainMessagePortRpcParent.create({
-    commandMap: {
-      'Viewlet.queueCommands': queueCommands,
-    },
+    commandMap: { 'Viewlet.queueCommands': queueCommands },
     messagePort: port1,
   })
+  const handleInput = jest.fn(async (_uid: number, _value: string) => {})
 
-  await handleMessagePort(port2)
-  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', []]])).resolves.toBe(31)
-  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', []]])
+  await handleMessagePort(port2, {
+    'StatusBar.handleInput': handleInput,
+  })
+  expect(RendererProcess.isConnected()).toBe(true)
+  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', 7, []]])).resolves.toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
 
   const requestRender = jest.fn(async (_uid: number) => {})
-  RendererWorker.set(Object.assign(createMockRpc({ commandMap: { 'Viewlet.requestRender': requestRender } }), { dispose: jest.fn() }))
-  const handleInput = jest.fn(async (_uid: number, _value: string) => {})
-  setCommandMap({ 'StatusBar.handleInput': handleInput })
+  RendererWorker.set(
+    Object.assign(
+      createMockRpc({
+        commandMap: {
+          'Viewlet.requestRender': requestRender,
+        },
+      }),
+      { dispose: jest.fn() },
+    ),
+  )
   await rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'handleInput', 'hello')
   expect(handleInput).toHaveBeenCalledWith(7, 'hello')
   expect(requestRender).toHaveBeenCalledWith(7)
   await expect(rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'missing')).rejects.toThrow('Viewlet command not found: missing')
 
-  await RendererProcess.dispose()
+  await RendererProcessRegistry.dispose()
   await RendererWorker.dispose()
   await rendererProcessRpc.dispose()
 })

--- a/packages/status-bar-worker/test/HandleMessagePort.test.ts
+++ b/packages/status-bar-worker/test/HandleMessagePort.test.ts
@@ -1,7 +1,7 @@
 import { expect, jest, test } from '@jest/globals'
-import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
-import { RendererProcess } from '@lvce-editor/rpc-registry'
-import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+import { createMockRpc, PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess, RendererWorker } from '@lvce-editor/rpc-registry'
+import { handleMessagePort, setCommandMap } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
 
 test('handleMessagePort connects the status bar worker to the renderer process', async () => {
   const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
@@ -17,6 +17,16 @@ test('handleMessagePort connects the status bar worker to the renderer process',
   await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', []]])).resolves.toBe(31)
   expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', []]])
 
+  const requestRender = jest.fn(async (_uid: number) => {})
+  RendererWorker.set(Object.assign(createMockRpc({ commandMap: { 'Viewlet.requestRender': requestRender } }), { dispose: jest.fn() }))
+  const handleInput = jest.fn(async (_uid: number, _value: string) => {})
+  setCommandMap({ 'StatusBar.handleInput': handleInput })
+  await rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'handleInput', 'hello')
+  expect(handleInput).toHaveBeenCalledWith(7, 'hello')
+  expect(requestRender).toHaveBeenCalledWith(7)
+  await expect(rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'missing')).rejects.toThrow('Viewlet command not found: missing')
+
   await RendererProcess.dispose()
+  await RendererWorker.dispose()
   await rendererProcessRpc.dispose()
 })


### PR DESCRIPTION
## Summary

- expose the worker command map on the renderer-process message port
- execute direct DOM events in the owning view worker
- request renderer-worker diff/render only after the state update succeeds

## Tests

- 37 suites, 197 tests passed
- TypeScript build passed