### PR TITLE
fix: update virtual dom sibling navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3025,9 +3025,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.104.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.104.9.tgz",
-      "integrity": "sha512-lDtJuuAGrodvOZg1JhmnSh34mDPXs78Ix9XGwRsv1s+VK5pazNOUkGoSqbzU368aK4tk7LvkN+kAkKgb/oqE7g==",
+      "version": "0.104.13",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.104.13.tgz",
+      "integrity": "sha512-/pb5UnACK9SmPv/fo+Ez6E9fHV/aTr4Qq20n+/bLc2rgvV4tcWJDJNISWewV9p7eAJ8baEWcOkZWmWsEQAOxYg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
@@ -3412,14 +3412,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.104.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.104.9.tgz",
-      "integrity": "sha512-5vjAm5xc364i0v54rEWJ/xgjNmZgqcN7U4rNBFeY7tF0l3hjfTRvJv29ZpdpqG5gJKhFUX4o7d1GPJjnOCGAvw==",
+      "version": "0.104.13",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.104.13.tgz",
+      "integrity": "sha512-P2e2KFqiR27vFifmX+ZzgAHwXCUipZHONRovhs0bZJht+IyGLdjm0DtarPuUJu3JsNTBwFXal0S6PXe7eOBFzw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/jsonc-parser": "^1.5.0",
-        "@lvce-editor/shared-process": "0.104.9",
-        "@lvce-editor/static-server": "0.104.9"
+        "@lvce-editor/shared-process": "0.104.13",
+        "@lvce-editor/static-server": "0.104.13"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3429,13 +3429,13 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.104.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.104.9.tgz",
-      "integrity": "sha512-PxR5478TcYo+9YffxkJNNnIZZk2yo4wPjiynOAO7qy65z7XYdAU6uGwzTY21Q16GI4CuFzFOg+g1HXD/z9k1MA==",
+      "version": "0.104.13",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.104.13.tgz",
+      "integrity": "sha512-kmhFQd1Gbt7q7bDDuJRvNcsI/+o/9jcCsS/FaqBRehxU6x77iH5z516WiUZcHFPNCx2aU8D47Nx4GNrwLxoJ0g==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.104.9",
+        "@lvce-editor/extension-host-helper-process": "0.104.13",
         "@lvce-editor/ipc": "16.12.0",
         "@lvce-editor/json-rpc": "8.7.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -3468,9 +3468,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.104.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.104.9.tgz",
-      "integrity": "sha512-pauEQebzoHRiNBA2JmVhr6eS9jVffGing9AYDPKUOAP1+c+Pk+LjzEL/amJ9DYisHovtzeMAAwRMUh5TXzE1BQ==",
+      "version": "0.104.13",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.104.13.tgz",
+      "integrity": "sha512-Dty17VgU7fKoFmNXo8nmmOk7UOOmqdcgSpPgtaxvVBRy5GbTygs28jbx1VIp77MFQ9L1a8PMWQNY/7PVLfHoyg==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -3555,13 +3555,13 @@
       }
     },
     "node_modules/@lvce-editor/virtual-dom-worker": {
-      "version": "9.13.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-9.13.0.tgz",
-      "integrity": "sha512-U22G4jStIuHidFFeo2gTTJu411OF8hs3fWamTan2GUxH2xjEa7xaVcdioDUEs7nfyi/h2utTbGxhXyuUTA73yw==",
+      "version": "11.13.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/virtual-dom-worker/-/virtual-dom-worker-11.13.2.tgz",
+      "integrity": "sha512-WSnZ5yoNycykwbwSvkgRFsimK70YoXYkOqaEl41PSeCgNRQrjhf3NXzSJpXO/5ZGZA99IxUPY6chZzVoKVjP3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/constants": "^5.13.0"
+        "@lvce-editor/constants": "^5.28.0"
       }
     },
     "node_modules/@lvce-editor/web-socket-server": {
@@ -15615,7 +15615,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "0.104.9"
+        "@lvce-editor/server": "0.104.13"
       }
     },
     "packages/status-bar-worker": {
@@ -15629,7 +15629,7 @@
         "@lvce-editor/rpc-registry": "^9.24.0",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^4.1.0",
-        "@lvce-editor/virtual-dom-worker": "^9.13.0",
+        "@lvce-editor/virtual-dom-worker": "^11.13.2",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.11"
       }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "0.104.9"
+    "@lvce-editor/server": "0.104.13"
   }
 }

--- a/packages/status-bar-worker/package.json
+++ b/packages/status-bar-worker/package.json
@@ -49,7 +49,7 @@
     "@lvce-editor/rpc-registry": "^9.24.0",
     "@lvce-editor/verror": "^1.7.0",
     "@lvce-editor/viewlet-registry": "^4.1.0",
-    "@lvce-editor/virtual-dom-worker": "^9.13.0",
+    "@lvce-editor/virtual-dom-worker": "^11.13.2",
     "jest": "^30.4.2",
     "ts-jest": "^29.4.11"
   }


### PR DESCRIPTION
Update the status bar worker to the virtual DOM release that correctly navigates to a parent before adding sibling nodes. Also validate the worker against the current LVCE server bundle so editor status items keep rendering after workspace changes.