### PR TITLE
fix: align right status bar items

### DIFF
--- a/packages/e2e/src/status-bar.editor-items.ts
+++ b/packages/e2e/src/status-bar.editor-items.ts
@@ -8,6 +8,13 @@ export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Wo
   await Workspace.setPath(tmpDir)
   await Main.openUri(`${tmpDir}/status-bar.ts`)
 
+  const itemsLeft = Locator('.StatusBarItemsLeft')
+  await expect(itemsLeft).toBeVisible()
+  await expect(itemsLeft.locator('.StatusBarItem')).toHaveCount(0)
+
+  const itemsRight = Locator('.StatusBarItemsRight')
+  await expect(itemsRight).toBeVisible()
+
   const position = Locator('.StatusBarItem[name="EditorPosition"]')
   const indentation = Locator('.StatusBarItem[name="EditorIndentation"]')
   const encoding = Locator('.StatusBarItem[name="EditorEncoding"]')

--- a/packages/e2e/src/status-bar.editor-items.ts
+++ b/packages/e2e/src/status-bar.editor-items.ts
@@ -2,11 +2,12 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'status-bar.editor-items'
 
-export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main, Workspace }) => {
+export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator, Main, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/status-bar.ts`, 'first\nsecond line')
   await Workspace.setPath(tmpDir)
   await Main.openUri(`${tmpDir}/status-bar.ts`)
+  await Command.execute('StatusBar.handleExtensionsChanged')
 
   const itemsLeft = Locator('.StatusBarItemsLeft')
   await expect(itemsLeft).toBeVisible()

--- a/packages/status-bar-worker/src/parts/GetStatusBarItemsLeftDom/GetStatusBarItemsLeftDom.ts
+++ b/packages/status-bar-worker/src/parts/GetStatusBarItemsLeftDom/GetStatusBarItemsLeftDom.ts
@@ -3,15 +3,17 @@ import type { StatusBarItem } from '../StatusBarItem/StatusBarItem.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as GetStatusBarItemsVirtualDom from '../GetStatusBarItemsVirtualDom/GetStatusBarItemsVirtualDom.ts'
 
+const emptyStatusBarItemsLeftDom: readonly VirtualDomNode[] = [
+  {
+    childCount: 0,
+    className: ClassNames.StatusBarItemsLeft,
+    type: VirtualDomElements.Div,
+  },
+]
+
 export const getStatusBarItemsLeftDom = (statusBarItemsLeft: readonly StatusBarItem[]): readonly VirtualDomNode[] => {
   if (statusBarItemsLeft.length === 0) {
-    return [
-      {
-        childCount: 0,
-        className: ClassNames.StatusBarItemsLeft,
-        type: VirtualDomElements.Div,
-      },
-    ]
+    return emptyStatusBarItemsLeftDom
   }
   return GetStatusBarItemsVirtualDom.getStatusBarItemsVirtualDom(statusBarItemsLeft, ClassNames.StatusBarItemsLeft)
 }

--- a/packages/status-bar-worker/src/parts/GetStatusBarItemsLeftDom/GetStatusBarItemsLeftDom.ts
+++ b/packages/status-bar-worker/src/parts/GetStatusBarItemsLeftDom/GetStatusBarItemsLeftDom.ts
@@ -1,8 +1,17 @@
-import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
+import { type VirtualDomNode, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { StatusBarItem } from '../StatusBarItem/StatusBarItem.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as GetStatusBarItemsVirtualDom from '../GetStatusBarItemsVirtualDom/GetStatusBarItemsVirtualDom.ts'
 
 export const getStatusBarItemsLeftDom = (statusBarItemsLeft: readonly StatusBarItem[]): readonly VirtualDomNode[] => {
+  if (statusBarItemsLeft.length === 0) {
+    return [
+      {
+        childCount: 0,
+        className: ClassNames.StatusBarItemsLeft,
+        type: VirtualDomElements.Div,
+      },
+    ]
+  }
   return GetStatusBarItemsVirtualDom.getStatusBarItemsVirtualDom(statusBarItemsLeft, ClassNames.StatusBarItemsLeft)
 }

--- a/packages/status-bar-worker/src/parts/GetStatusBarVirtualDom/GetStatusBarVirtualDom.ts
+++ b/packages/status-bar-worker/src/parts/GetStatusBarVirtualDom/GetStatusBarVirtualDom.ts
@@ -4,15 +4,8 @@ import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEven
 import * as GetStatusBarItemsLeftDom from '../GetStatusBarItemsLeftDom/GetStatusBarItemsLeftDom.ts'
 import * as GetStatusBarItemsRightDom from '../GetStatusBarItemsRightDom/GetStatusBarItemsRightDom.ts'
 
-const getChildCount = (leftCount: number, rightCount: number): number => {
-  let count = 0
-  if (leftCount > 0) {
-    count++
-  }
-  if (rightCount > 0) {
-    count++
-  }
-  return count
+const getChildCount = (rightCount: number): number => {
+  return rightCount > 0 ? 2 : 1
 }
 
 export const getStatusBarVirtualDom = (
@@ -21,7 +14,7 @@ export const getStatusBarVirtualDom = (
 ): readonly VirtualDomNode[] => {
   const dom: VirtualDomNode[] = [
     {
-      childCount: getChildCount(statusBarItemsLeft.length, statusBarItemsRight.length),
+      childCount: getChildCount(statusBarItemsRight.length),
       className: 'StatusBar',
       onClick: DomEventListenerFunctions.HandleClick,
       onContextMenu: DomEventListenerFunctions.HandleContextMenu,

--- a/packages/status-bar-worker/test/GetStatusBarVirtualDom.test.ts
+++ b/packages/status-bar-worker/test/GetStatusBarVirtualDom.test.ts
@@ -5,13 +5,18 @@ import * as ClassNames from '../src/parts/ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as GetStatusBarVirtualDom from '../src/parts/GetStatusBarVirtualDom/GetStatusBarVirtualDom.ts'
 
-test('getStatusBarVirtualDom should return empty array when both arrays are empty', () => {
+test('getStatusBarVirtualDom should render an empty left container when both arrays are empty', () => {
   const result = GetStatusBarVirtualDom.getStatusBarVirtualDom([], [])
-  expect(result.length).toBeGreaterThan(0)
   expect(result[0]).toMatchObject({
+    childCount: 1,
     className: 'StatusBar',
     onContextMenu: DomEventListenerFunctions.HandleContextMenu,
     type: 4,
+  })
+  expect(result[1]).toEqual({
+    childCount: 0,
+    className: ClassNames.StatusBarItemsLeft,
+    type: VirtualDomElements.Div,
   })
 })
 
@@ -44,8 +49,14 @@ test('getStatusBarVirtualDom should return items for right when only right has i
     },
   ]
   const result = GetStatusBarVirtualDom.getStatusBarVirtualDom([], rightItems)
-  expect(result.length).toBeGreaterThan(0)
+  expect(result[0].childCount).toBe(2)
+  const leftDiv = result.find((node) => node.className === ClassNames.StatusBarItemsLeft)
   const rightDiv = result.find((node) => node.className === ClassNames.StatusBarItemsRight)
+  expect(leftDiv).toEqual({
+    childCount: 0,
+    className: ClassNames.StatusBarItemsLeft,
+    type: VirtualDomElements.Div,
+  })
   expect(rightDiv).toBeDefined()
   expect(rightDiv).toMatchObject({
     className: ClassNames.StatusBarItemsRight,


### PR DESCRIPTION
Render the left status bar item container even when it is empty so right-side items remain aligned to the right edge. Extend unit and end-to-end coverage for empty-left/right-only layouts.