### PR TITLE
fix: allow commandless extension status bar items

### DIFF
--- a/packages/status-bar-worker/src/parts/HandleClick/HandleClick.ts
+++ b/packages/status-bar-worker/src/parts/HandleClick/HandleClick.ts
@@ -19,8 +19,8 @@ export const handleClick = async (state: StatusBarState, name: string): Promise<
     await handleClickNotification()
   } else if (item.name === InputName.Problems) {
     await handleClickProblems()
-  } else if (!InputName.isEditorStatus(item.name)) {
-    await handleClickExtensionStatusBarItem(name)
+  } else if (item.command && !InputName.isEditorStatus(item.name)) {
+    await handleClickExtensionStatusBarItem(item.command)
   }
   // TODO
   // sendExtensionWorker([/* statusBarItemHandleClick */ 7657, /* name */ name])

--- a/packages/status-bar-worker/src/parts/ToUiStatusBarItem/ToUiStatusBarItem.ts
+++ b/packages/status-bar-worker/src/parts/ToUiStatusBarItem/ToUiStatusBarItem.ts
@@ -10,7 +10,7 @@ const getActualIcon = (extensionStatusBarItem: any): string => {
 export const toUiStatusBarItem = (extensionStatusBarItem: any): UiStatusBarItem => {
   return {
     ariaLabel: extensionStatusBarItem.ariaLabel || '',
-    command: extensionStatusBarItem.command || '',
+    command: extensionStatusBarItem.onClick || extensionStatusBarItem.command || '',
     icon: getActualIcon(extensionStatusBarItem),
     name: extensionStatusBarItem.id || extensionStatusBarItem.name || '',
     ...(extensionStatusBarItem.spinning === true && { spinning: true }),

--- a/packages/status-bar-worker/test/HandleClick.test.ts
+++ b/packages/status-bar-worker/test/HandleClick.test.ts
@@ -96,7 +96,7 @@ test('handleClick should call handleClickExtensionStatusBarItem for extension it
   expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'my.extension.command'])
 })
 
-test('handleClick should do nothing for a commandless extension item in statusBarItemsLeft', async () => {
+test('handleClick should do nothing for an extension item without a command in statusBarItemsLeft', async () => {
   using mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
     'Extensions.executeCommand': async () => {},
   })
@@ -119,7 +119,7 @@ test('handleClick should do nothing for a commandless extension item in statusBa
   expect(mockExtensionManagementRpc.invocations).toEqual([])
 })
 
-test('handleClick should do nothing for a commandless extension item in statusBarItemsRight', async () => {
+test('handleClick should do nothing for an extension item without a command in statusBarItemsRight', async () => {
   using mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
     'Extensions.executeCommand': async () => {},
   })

--- a/packages/status-bar-worker/test/HandleClick.test.ts
+++ b/packages/status-bar-worker/test/HandleClick.test.ts
@@ -93,10 +93,10 @@ test('handleClick should call handleClickExtensionStatusBarItem for extension it
 
   await HandleClick.handleClick(state, 'my-extension-item')
 
-  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'my-extension-item'])
+  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'my.extension.command'])
 })
 
-test('handleClick should find item in statusBarItemsLeft', async () => {
+test('handleClick should do nothing for a commandless extension item in statusBarItemsLeft', async () => {
   using mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
     'Extensions.executeCommand': async () => {},
   })
@@ -116,10 +116,10 @@ test('handleClick should find item in statusBarItemsLeft', async () => {
 
   await HandleClick.handleClick(state, 'left-item')
 
-  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'left-item'])
+  expect(mockExtensionManagementRpc.invocations).toEqual([])
 })
 
-test('handleClick should find item in statusBarItemsRight', async () => {
+test('handleClick should do nothing for a commandless extension item in statusBarItemsRight', async () => {
   using mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
     'Extensions.executeCommand': async () => {},
   })
@@ -139,7 +139,7 @@ test('handleClick should find item in statusBarItemsRight', async () => {
 
   await HandleClick.handleClick(state, 'right-item')
 
-  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'right-item'])
+  expect(mockExtensionManagementRpc.invocations).toEqual([])
 })
 
 test('handleClick should prioritize left items over right items with same name', async () => {
@@ -171,7 +171,7 @@ test('handleClick should prioritize left items over right items with same name',
 
   await HandleClick.handleClick(state, 'duplicate-item')
 
-  expect(mockExtensionManagementRpc.invocations).toEqual([['Extensions.executeCommand', 'duplicate-item']])
+  expect(mockExtensionManagementRpc.invocations).toEqual([['Extensions.executeCommand', 'left.command']])
 })
 
 test('handleClick should handle extension item with command property', async () => {
@@ -195,7 +195,7 @@ test('handleClick should handle extension item with command property', async () 
 
   await HandleClick.handleClick(state, 'extension-with-command')
 
-  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'extension-with-command'])
+  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'my.extension.command'])
 })
 
 test('handleClick should handle multiple items in left array', async () => {
@@ -208,18 +208,21 @@ test('handleClick should handle multiple items in left array', async () => {
     statusBarItemsLeft: [
       {
         ariaLabel: 'Item 1',
+        command: 'command-1',
         elements: [],
         name: 'item-1',
         tooltip: 'Item 1',
       },
       {
         ariaLabel: 'Item 2',
+        command: 'command-2',
         elements: [],
         name: 'item-2',
         tooltip: 'Item 2',
       },
       {
         ariaLabel: 'Item 3',
+        command: 'command-3',
         elements: [],
         name: 'item-3',
         tooltip: 'Item 3',
@@ -230,7 +233,7 @@ test('handleClick should handle multiple items in left array', async () => {
 
   await HandleClick.handleClick(state, 'item-2')
 
-  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'item-2'])
+  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'command-2'])
 })
 
 test('handleClick should handle multiple items in right array', async () => {
@@ -244,18 +247,21 @@ test('handleClick should handle multiple items in right array', async () => {
     statusBarItemsRight: [
       {
         ariaLabel: 'Right 1',
+        command: 'right-command-1',
         elements: [],
         name: 'right-1',
         tooltip: 'Right 1',
       },
       {
         ariaLabel: 'Right 2',
+        command: 'right-command-2',
         elements: [],
         name: 'right-2',
         tooltip: 'Right 2',
       },
       {
         ariaLabel: 'Right 3',
+        command: 'right-command-3',
         elements: [],
         name: 'right-3',
         tooltip: 'Right 3',
@@ -265,7 +271,7 @@ test('handleClick should handle multiple items in right array', async () => {
 
   await HandleClick.handleClick(state, 'right-2')
 
-  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'right-2'])
+  expect(mockExtensionManagementRpc.invocations).toContainEqual(['Extensions.executeCommand', 'right-command-2'])
 })
 
 test('handleClick should not call RPC methods for empty name', async () => {

--- a/packages/status-bar-worker/test/StatusBarItemConversion.test.ts
+++ b/packages/status-bar-worker/test/StatusBarItemConversion.test.ts
@@ -99,6 +99,25 @@ test('toUiStatusBarItem should normalize branch icon', () => {
   })
 })
 
+test('toUiStatusBarItem should use onClick as the command', () => {
+  const result = ToUiStatusBarItem.toUiStatusBarItem({
+    id: 'test-item',
+    onClick: 'test.command',
+    text: 'Test',
+  })
+
+  expect(result.command).toBe('test.command')
+})
+
+test('toUiStatusBarItem should allow the command to be omitted', () => {
+  const result = ToUiStatusBarItem.toUiStatusBarItem({
+    id: 'test-item',
+    text: 'Test',
+  })
+
+  expect(result.command).toBe('')
+})
+
 test('toStatusBarItem should prefer the extension aria label', () => {
   const uiStatusBarItem = ToUiStatusBarItem.toUiStatusBarItem({
     ariaLabel: 'workspace (Git) - Pull 2 commits from origin/main',


### PR DESCRIPTION
Allow extension status bar items to omit their command so clicks remain inert. Preserve explicit onClick commands and execute the command value instead of the item name.