### PR TITLE
feature: add editor status bar actions

### DIFF
--- a/packages/e2e/src/status-bar.editor-actions.ts
+++ b/packages/e2e/src/status-bar.editor-actions.ts
@@ -1,0 +1,37 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'status-bar.editor-actions'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/status-bar.ts`, 'first\nsecond line')
+  await Workspace.setPath(tmpDir)
+  await Main.openUri(`${tmpDir}/status-bar.ts`)
+  await Editor.setCursor(1, 6)
+
+  await Command.execute('StatusBar.handleClick', 0, 'EditorPosition')
+  const quickPickInput = Locator('#QuickPick .InputBox')
+  await expect(quickPickInput).toHaveValue(':2:7')
+  await Command.execute('QuickPick.close')
+
+  await Command.execute('StatusBar.handleClick', 0, 'EditorIndentation')
+  const quickPickItems = Locator('.QuickPickItemLabel')
+  const spaces = quickPickItems.nth(0)
+  const tabs = quickPickItems.nth(1)
+  await expect(spaces).toHaveText('Indent Using Spaces')
+  await expect(tabs).toHaveText('Indent Using Tabs')
+  await Command.execute('QuickPick.close')
+
+  await Command.execute('StatusBar.handleClick', 0, 'EditorEndOfLine')
+  const lf = quickPickItems.nth(0)
+  const crlf = quickPickItems.nth(1)
+  await expect(lf).toHaveText('LF')
+  await expect(crlf).toHaveText('CRLF')
+  await Command.execute('QuickPick.close')
+
+  await Command.execute('StatusBar.handleClick', 0, 'EditorLanguage')
+  const quickPick = Locator('#QuickPick')
+  await expect(quickPick).toBeVisible()
+}

--- a/packages/e2e/src/status-bar.editor-items.ts
+++ b/packages/e2e/src/status-bar.editor-items.ts
@@ -19,11 +19,13 @@ export const test: Test = async ({ Command, Editor, expect, FileSystem, Locator,
   const position = Locator('.StatusBarItem[name="EditorPosition"]')
   const indentation = Locator('.StatusBarItem[name="EditorIndentation"]')
   const encoding = Locator('.StatusBarItem[name="EditorEncoding"]')
+  const endOfLine = Locator('.StatusBarItem[name="EditorEndOfLine"]')
   const language = Locator('.StatusBarItem[name="EditorLanguage"]')
   const utf8Display = ['UTF', '8'].join('-')
   await expect(position).toHaveText('Ln 1, Col 1')
   await expect(indentation).toHaveText('Spaces: 2')
   await expect(encoding).toHaveText(utf8Display)
+  await expect(endOfLine).toHaveText('LF')
   await expect(language).toHaveText('typescript')
 
   await Editor.setCursor(1, 6)

--- a/packages/status-bar-worker/src/parts/EditorStatus/EditorStatus.ts
+++ b/packages/status-bar-worker/src/parts/EditorStatus/EditorStatus.ts
@@ -1,6 +1,8 @@
 export interface EditorStatus {
   readonly column: number
   readonly encoding: string
+  readonly endOfLine: string
+  readonly insertSpaces: boolean
   readonly languageId: string
   readonly line: number
   readonly tabSize: number

--- a/packages/status-bar-worker/src/parts/GetEditorStatusBarItems/GetEditorStatusBarItems.ts
+++ b/packages/status-bar-worker/src/parts/GetEditorStatusBarItems/GetEditorStatusBarItems.ts
@@ -14,12 +14,15 @@ export const getEditorStatusBarItems = (status: EditorStatus | undefined): reado
   if (!status) {
     return []
   }
-  const { column, encoding, languageId, line, tabSize } = status
+  const { column, encoding, endOfLine = 'lf', insertSpaces = true, languageId, line, tabSize } = status
   const encodingLabel = encoding === 'utf8' ? ['UTF', '8'].join('-') : encoding
+  const indentationLabel = insertSpaces ? `Spaces: ${tabSize}` : `Tab Size: ${tabSize}`
+  const endOfLineLabel = endOfLine.toUpperCase()
   return [
     textItem(InputName.EditorPosition, `Ln ${line}, Col ${column}`, `Line ${line}, Column ${column}`, 'Go to Line/Column'),
-    textItem(InputName.EditorIndentation, `Spaces: ${tabSize}`, `Spaces: ${tabSize}`, 'Select Indentation'),
+    textItem(InputName.EditorIndentation, indentationLabel, indentationLabel, 'Select Indentation'),
     textItem(InputName.EditorEncoding, encodingLabel, `Encoding: ${encodingLabel}`, 'Select Encoding'),
+    textItem(InputName.EditorEndOfLine, endOfLineLabel, `End of Line: ${endOfLineLabel}`, 'Select End of Line Sequence'),
     textItem(InputName.EditorLanguage, languageId, `Language: ${languageId}`, 'Select Language Mode'),
   ]
 }

--- a/packages/status-bar-worker/src/parts/HandleClick/HandleClick.ts
+++ b/packages/status-bar-worker/src/parts/HandleClick/HandleClick.ts
@@ -1,5 +1,6 @@
 import type { StatusBarState } from '../StatusBarState/StatusBarState.ts'
 import { getMatchingItem } from '../GetMatchingItem/GetMatchingItem.ts'
+import { handleClickEditorStatus } from '../HandleClickEditorStatus/HandleClickEditorStatus.ts'
 import { handleClickExtensionStatusBarItem } from '../HandleClickExtensionStatusBarItem/HandleClickExtensionStatusBarItem.ts'
 import { handleClickNotification } from '../HandleClickNotification/HandleClickNotification.ts'
 import { handleClickProblems } from '../HandleClickProblems/HandleClickProblems.ts'
@@ -9,7 +10,7 @@ export const handleClick = async (state: StatusBarState, name: string): Promise<
   if (!name) {
     return state
   }
-  const { statusBarItemsLeft, statusBarItemsRight } = state
+  const { editorStatus, statusBarItemsLeft, statusBarItemsRight } = state
 
   const item = getMatchingItem(statusBarItemsLeft, statusBarItemsRight, name)
   if (!item) {
@@ -19,6 +20,8 @@ export const handleClick = async (state: StatusBarState, name: string): Promise<
     await handleClickNotification()
   } else if (item.name === InputName.Problems) {
     await handleClickProblems()
+  } else if (InputName.isEditorStatus(item.name)) {
+    await handleClickEditorStatus(item.name, editorStatus)
   } else if (item.command && !InputName.isEditorStatus(item.name)) {
     await handleClickExtensionStatusBarItem(item.command)
   }

--- a/packages/status-bar-worker/src/parts/HandleClickEditorStatus/HandleClickEditorStatus.ts
+++ b/packages/status-bar-worker/src/parts/HandleClickEditorStatus/HandleClickEditorStatus.ts
@@ -1,0 +1,23 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { EditorStatus } from '../EditorStatus/EditorStatus.ts'
+import * as InputName from '../InputName/InputName.ts'
+
+export const handleClickEditorStatus = async (name: string, status: EditorStatus | undefined): Promise<void> => {
+  if (!status) {
+    return
+  }
+  switch (name) {
+    case InputName.EditorEndOfLine:
+      await RendererWorker.invoke('Viewlet.openWidget', 'QuickPick', 'end-of-line')
+      return
+    case InputName.EditorIndentation:
+      await RendererWorker.invoke('Viewlet.openWidget', 'QuickPick', 'indentation')
+      return
+    case InputName.EditorLanguage:
+      await RendererWorker.invoke('Viewlet.openWidget', 'QuickPick', 'language-mode')
+      return
+    case InputName.EditorPosition:
+      await RendererWorker.invoke('Viewlet.openWidget', 'QuickPick', 'go-to-line', status.line, status.column)
+      return
+  }
+}

--- a/packages/status-bar-worker/src/parts/HandleEditorStatusChanged/HandleEditorStatusChanged.ts
+++ b/packages/status-bar-worker/src/parts/HandleEditorStatusChanged/HandleEditorStatusChanged.ts
@@ -10,7 +10,9 @@ const equals = (oldStatus: EditorStatus | undefined, newStatus: EditorStatus | u
   }
   return (
     oldStatus.column === newStatus.column &&
+    oldStatus.endOfLine === newStatus.endOfLine &&
     oldStatus.encoding === newStatus.encoding &&
+    oldStatus.insertSpaces === newStatus.insertSpaces &&
     oldStatus.languageId === newStatus.languageId &&
     oldStatus.line === newStatus.line &&
     oldStatus.tabSize === newStatus.tabSize

--- a/packages/status-bar-worker/src/parts/InputName/InputName.ts
+++ b/packages/status-bar-worker/src/parts/InputName/InputName.ts
@@ -1,4 +1,5 @@
 export const EditorEncoding = 'EditorEncoding'
+export const EditorEndOfLine = 'EditorEndOfLine'
 export const EditorIndentation = 'EditorIndentation'
 export const EditorLanguage = 'EditorLanguage'
 export const EditorPosition = 'EditorPosition'
@@ -6,7 +7,7 @@ export const Notifications = 'Notifications'
 export const Problems = 'Problems'
 
 export const isEditorStatus = (name: string): boolean => {
-  return [EditorEncoding, EditorIndentation, EditorLanguage, EditorPosition].includes(name)
+  return [EditorEncoding, EditorEndOfLine, EditorIndentation, EditorLanguage, EditorPosition].includes(name)
 }
 
 export const isRight = (name: string): boolean => {

--- a/packages/status-bar-worker/test/GetEditorStatusBarItems.test.ts
+++ b/packages/status-bar-worker/test/GetEditorStatusBarItems.test.ts
@@ -1,11 +1,13 @@
 import { expect, test } from '@jest/globals'
 import { getEditorStatusBarItems } from '../src/parts/GetEditorStatusBarItems/GetEditorStatusBarItems.ts'
 
-test('returns the four editor status items', () => {
+test('returns the five editor status items', () => {
   expect(
     getEditorStatusBarItems({
       column: 7,
       encoding: 'utf8',
+      endOfLine: 'lf',
+      insertSpaces: true,
       languageId: 'javascript',
       line: 2,
       tabSize: 4,
@@ -14,8 +16,24 @@ test('returns the four editor status items', () => {
     expect.objectContaining({ elements: [{ type: 'text', value: 'Ln 2, Col 7' }], name: 'EditorPosition' }),
     expect.objectContaining({ elements: [{ type: 'text', value: 'Spaces: 4' }], name: 'EditorIndentation' }),
     expect.objectContaining({ elements: [{ type: 'text', value: ['UTF', '8'].join('-') }], name: 'EditorEncoding' }),
+    expect.objectContaining({ elements: [{ type: 'text', value: 'LF' }], name: 'EditorEndOfLine' }),
     expect.objectContaining({ elements: [{ type: 'text', value: 'javascript' }], name: 'EditorLanguage' }),
   ])
+})
+
+test('shows tab indentation', () => {
+  const result = getEditorStatusBarItems({
+    column: 1,
+    encoding: 'utf8',
+    endOfLine: 'crlf',
+    insertSpaces: false,
+    languageId: 'plaintext',
+    line: 1,
+    tabSize: 4,
+  })
+
+  expect(result[1].elements).toEqual([{ type: 'text', value: 'Tab Size: 4' }])
+  expect(result[3].elements).toEqual([{ type: 'text', value: 'CRLF' }])
 })
 
 test('returns no items without an active editor', () => {

--- a/packages/status-bar-worker/test/HandleClick.test.ts
+++ b/packages/status-bar-worker/test/HandleClick.test.ts
@@ -318,3 +318,60 @@ test('handleClick should not call RPC methods for item not found', async () => {
   expect(mockRendererRpc.invocations).toEqual([])
   expect(mockExtensionManagementRpc.invocations).toEqual([])
 })
+
+const editorStatus = {
+  column: 5,
+  encoding: 'utf8',
+  endOfLine: 'lf',
+  insertSpaces: true,
+  languageId: 'typescript',
+  line: 3,
+  tabSize: 2,
+}
+
+const createEditorStatusState = (name: string): StatusBarState => ({
+  ...createDefaultState(),
+  editorStatus,
+  statusBarItemsLeft: [],
+  statusBarItemsRight: [{ ariaLabel: name, elements: [], name, tooltip: name }],
+})
+
+test('handleClick should open go to line with the current position', async () => {
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    'Viewlet.openWidget': async () => {},
+  })
+
+  await HandleClick.handleClick(createEditorStatusState('EditorPosition'), 'EditorPosition')
+
+  expect(mockRendererRpc.invocations).toEqual([['Viewlet.openWidget', 'QuickPick', 'go-to-line', 3, 5]])
+})
+
+test('handleClick should open the indentation picker', async () => {
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    'Viewlet.openWidget': async () => {},
+  })
+
+  await HandleClick.handleClick(createEditorStatusState('EditorIndentation'), 'EditorIndentation')
+
+  expect(mockRendererRpc.invocations).toEqual([['Viewlet.openWidget', 'QuickPick', 'indentation']])
+})
+
+test('handleClick should open the end of line picker', async () => {
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    'Viewlet.openWidget': async () => {},
+  })
+
+  await HandleClick.handleClick(createEditorStatusState('EditorEndOfLine'), 'EditorEndOfLine')
+
+  expect(mockRendererRpc.invocations).toEqual([['Viewlet.openWidget', 'QuickPick', 'end-of-line']])
+})
+
+test('handleClick should open the language mode picker', async () => {
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    'Viewlet.openWidget': async () => {},
+  })
+
+  await HandleClick.handleClick(createEditorStatusState('EditorLanguage'), 'EditorLanguage')
+
+  expect(mockRendererRpc.invocations).toEqual([['Viewlet.openWidget', 'QuickPick', 'language-mode']])
+})

--- a/packages/status-bar-worker/test/HandleEditorStatusChanged.test.ts
+++ b/packages/status-bar-worker/test/HandleEditorStatusChanged.test.ts
@@ -5,6 +5,8 @@ import { handleEditorStatusChanged } from '../src/parts/HandleEditorStatusChange
 const editorStatus = {
   column: 1,
   encoding: 'utf8',
+  endOfLine: 'lf',
+  insertSpaces: true,
   languageId: 'plaintext',
   line: 1,
   tabSize: 4,
@@ -20,6 +22,7 @@ test('adds editor items before notifications', () => {
     'EditorPosition',
     'EditorIndentation',
     'EditorEncoding',
+    'EditorEndOfLine',
     'EditorLanguage',
     'Notifications',
   ])
@@ -35,12 +38,13 @@ test('updates editor values and preserves other right items', () => {
     'EditorPosition',
     'EditorIndentation',
     'EditorEncoding',
+    'EditorEndOfLine',
     'EditorLanguage',
     'Notifications',
   ])
   expect(result.statusBarItemsRight[0].elements).toEqual([{ type: 'text', value: 'Ln 3, Col 8' }])
   expect(result.statusBarItemsRight[1].elements).toEqual([{ type: 'text', value: 'Spaces: 2' }])
-  expect(result.statusBarItemsRight[3].elements).toEqual([{ type: 'text', value: 'typescript' }])
+  expect(result.statusBarItemsRight[4].elements).toEqual([{ type: 'text', value: 'typescript' }])
 })
 
 test('removes editor items when the last editor closes', () => {

--- a/packages/status-bar-worker/test/HandleEditorStatusChangedAll.test.ts
+++ b/packages/status-bar-worker/test/HandleEditorStatusChangedAll.test.ts
@@ -6,7 +6,7 @@ import { handleEditorStatusChangedAll } from '../src/parts/HandleEditorStatusCha
 import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 import * as StatusBarStates from '../src/parts/StatusBarStates/StatusBarStates.ts'
 
-const editorStatus = { column: 7, encoding: 'utf8', languageId: 'javascript', line: 2, tabSize: 4 }
+const editorStatus = { column: 7, encoding: 'utf8', endOfLine: 'lf', insertSpaces: true, languageId: 'javascript', line: 2, tabSize: 4 }
 
 afterEach(() => {
   EditorStatusState.reset()

--- a/packages/status-bar-worker/test/LoadContent.test.ts
+++ b/packages/status-bar-worker/test/LoadContent.test.ts
@@ -42,7 +42,7 @@ test('uses editor status received before content is loading', async () => {
     'Extensions.getNotificationCount': async () => 0,
     'Extensions.getStatusBarItems': async () => [],
   })
-  EditorStatusState.set({ column: 7, encoding: 'utf8', languageId: 'javascript', line: 2, tabSize: 4 })
+  EditorStatusState.set({ column: 7, encoding: 'utf8', endOfLine: 'lf', insertSpaces: true, languageId: 'javascript', line: 2, tabSize: 4 })
 
   const result = await loadContent(createDefaultState())
 
@@ -50,6 +50,7 @@ test('uses editor status received before content is loading', async () => {
     'EditorPosition',
     'EditorIndentation',
     'EditorEncoding',
+    'EditorEndOfLine',
     'EditorLanguage',
     'Notifications',
   ])


### PR DESCRIPTION
Makes the language, cursor position, line-ending, and indentation status items open their corresponding quick picks.