### PR TITLE
Contribute status bar settings

### DIFF
--- a/packages/build/src/build.js
+++ b/packages/build/src/build.js
@@ -70,5 +70,6 @@ packageJson.main = 'dist/statusBarWorkerMain.js'
 
 await writeJson(join(dist, 'package.json'), packageJson)
 
+await cp(join(root, 'packages', 'status-bar-worker', 'settings.json'), join(dist, 'dist', 'settings.json'))
 await cp(join(root, 'README.md'), join(dist, 'README.md'))
 await cp(join(root, 'LICENSE'), join(dist, 'LICENSE'))

--- a/packages/status-bar-worker/settings.json
+++ b/packages/status-bar-worker/settings.json
@@ -1,0 +1,26 @@
+[
+  {
+    "category": "workbench",
+    "description": "Controls whether status bar items are visible.",
+    "heading": "Show Status Bar Items",
+    "id": "statusBar.itemsVisible",
+    "type": 3,
+    "value": "true"
+  },
+  {
+    "category": "workbench",
+    "description": "Controls whether the built-in notifications item is shown in the status bar.",
+    "heading": "Show Notifications Status",
+    "id": "statusBar.builtinNotificationsEnabled",
+    "type": 3,
+    "value": "true"
+  },
+  {
+    "category": "workbench",
+    "description": "Controls whether the built-in problems item is shown in the status bar.",
+    "heading": "Show Problems Status",
+    "id": "statusBar.builtinProblemsEnabled",
+    "type": 3,
+    "value": "true"
+  }
+]


### PR DESCRIPTION
Publishes the status bar visibility settings with the status bar worker package so LVCE can bundle them into the built-in settings catalog.

Tests: npm run lint; npm run type-check; npm test; npm run build; verified dist/settings.json